### PR TITLE
Configurable remove_tags for abstracts, and substitute mathml formula…

### DIFF
--- a/elifepubmed/conf.py
+++ b/elifepubmed/conf.py
@@ -17,6 +17,7 @@ def parse_raw_config(raw_config):
     list_values.append("author_contrib_types")
     list_values.append("group_author_contrib_types")
     list_values.append("history_date_types")
+    list_values.append("remove_tags")
 
     for value_name in raw_config:
         if value_name in boolean_values:

--- a/elifepubmed/generate.py
+++ b/elifepubmed/generate.py
@@ -386,6 +386,7 @@ class PubMedXML(object):
         # Pubmed allows <i> tags, not <italic> tags
         if poa_article.abstract:
             tag_converted_abstract = poa_article.abstract
+            tag_converted_abstract = utils.replace_mathml_tags(tag_converted_abstract)
             tag_converted_abstract = eautils.replace_tags(tag_converted_abstract, 'italic', 'i')
             tag_converted_abstract = eautils.replace_tags(tag_converted_abstract, 'bold', 'b')
             tag_converted_abstract = eautils.replace_tags(tag_converted_abstract, 'underline', 'u')
@@ -528,9 +529,10 @@ def build_articles_for_pubmed(article_xmls, config_section="elife"):
     raw_config = config[config_section]
     pubmed_config = parse_raw_config(raw_config)
     build_parts = pubmed_config.get('build_parts')
-    return build_articles(article_xmls, build_parts)
+    remove_tags = pubmed_config.get('remove_tags')
+    return build_articles(article_xmls, build_parts, remove_tags)
 
 
-def build_articles(article_xmls, build_parts=None):
+def build_articles(article_xmls, build_parts=None, remove_tags=None):
     return parse.build_articles_from_article_xmls(
-        article_xmls, detail="full", build_parts=build_parts)
+        article_xmls, detail="full", build_parts=build_parts, remove_tags=remove_tags)

--- a/elifepubmed/utils.py
+++ b/elifepubmed/utils.py
@@ -1,3 +1,4 @@
+import re
 
 def allowed_tags():
     "tuple of whitelisted tags"
@@ -14,3 +15,13 @@ def allowed_tags():
         '<bold>', '</bold>',
         '<p>', '</p>'
     )
+
+def replace_mathml_tags(string, replacement="[Formula: see text]"):
+    if not string:
+        return string
+    # match over newlines with DOTALL for kitchen sink testing and if found in real articles
+    for tag_match in re.finditer("<inline-formula>(.*?)</inline-formula>", string, re.DOTALL):
+        tag_content = tag_match.group(1)
+        old_tag = '<inline-formula>' + tag_content + '</inline-formula>'
+        string = string.replace(old_tag, replacement)
+    return string

--- a/pubmed.cfg
+++ b/pubmed.cfg
@@ -7,6 +7,8 @@ language: EN
 batch_file_prefix: pubmed-
 # default build parts when parsing article XML, omits the is_poa part which is eLife specific
 build_parts: ['abstract', 'basic', 'categories', 'components', 'contributors', 'datasets', 'funding', 'history', 'keywords', 'license', 'pub_dates', 'references', 'related_articles', 'research_organisms', 'volume']
+# tags to remove when cleaning the abstract from article XML
+remove_tags: ["xref", "ext-link"]
 author_contrib_types: ["author"]
 group_author_contrib_types: ["author non-byline", "on-behalf-of"]
 history_date_types: ["received", "accepted"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 git+https://github.com/elifesciences/elife-tools.git@05def8780aaf7ffb247c409ad77d62d186f1abdd#egg=elifetools
-git+https://github.com/elifesciences/elife-article.git@af8bd6feb0642653264e53d6fffda4c5f6ecad88#egg=elifearticle
+git+https://github.com/elifesciences/elife-article.git@ddf7d505f60d86a17099cd278fdd517dfd3d2680#egg=elifearticle
 GitPython==0.3.2.1
 configparser==3.5.0

--- a/tests/test_data/elife-pubmed-00666-20170717071707.xml
+++ b/tests/test_data/elife-pubmed-00666-20170717071707.xml
@@ -2,26 +2,7 @@
                     An abstract can contain any formatting, such as <i>italics</i>,
                         <b>bold</b>, <sup>superscript</sup>, <sub>subscript</sub> or small caps. MathML is
                     also allowed: 
-                    
-
-
-
-m
-
-
-
-
-p
-
-
-m
-
-=
-0
-
-
-
-
+                    [Formula: see text]
                 .eLife does not structure abstracts into sub headings expect in a clinical trial article, but the abstract can have
                     multiple paragarahs. The sub DOI is always .001 as it is the first asset in any
                     article. I have added an unmatched &gt; bracket as this has been an issue for PubMed deposits in the past.If this was a clinical trial the clinical trial details would be listed at the end of the abstract:Clinical trial Registration: EudraCT2004-000446-20.</Abstract><CopyrightInformation>© 2016, Harrison et al</CopyrightInformation><ObjectList><Object Type="keyword"><Param Name="value">human</Param></Object><Object Type="keyword"><Param Name="value">machine</Param></Object><Object Type="keyword"><Param Name="value">cell biology</Param></Object><Object Type="keyword"><Param Name="value">plant biology</Param></Object><Object Type="keyword"><Param Name="value">XML</Param></Object><Object Type="keyword"><Param Name="value">Housestyle</Param></Object><Object Type="keyword"><Param Name="value">eLife</Param></Object><Object Type="keyword"><Param Name="value">

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,5 +6,24 @@ class TestUtils(unittest.TestCase):
     def test_allowed_tags(self):
         self.assertIsNotNone(utils.allowed_tags(), 'allowed_tags not returned')
 
+    def test_replace_mathml_tags(self):
+        self.assertEqual(
+            utils.replace_mathml_tags(None), None)
+        self.assertEqual(
+            utils.replace_mathml_tags('test'), 'test')
+        self.assertEqual(
+            utils.replace_mathml_tags(
+                '<inline-formula><mml:math>m</mml:math></inline-formula>'),
+                '[Formula: see text]')
+        self.assertEqual(
+            utils.replace_mathml_tags(
+                '<inline-formula><mml:math>m</mml:math></inline-formula><inline-formula></inline-formula>'),
+                '[Formula: see text][Formula: see text]')
+        # test newline matches
+        self.assertEqual(
+            utils.replace_mathml_tags(
+                "\n<inline-formula>\n\n<mml:math>m</mml:math>\n</inline-formula>\n"),
+                "\n[Formula: see text]\n")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
…e in the abstract with the PubMed suggested placeholder.

Fixes https://github.com/elifesciences/elife-pubmed-feed/issues/64.