### PR TITLE
Replaces tag logic hook

### DIFF
--- a/elifepubmed/generate.py
+++ b/elifepubmed/generate.py
@@ -150,9 +150,13 @@ class PubMedXML(object):
         """
         Set the Replaces tag, if applicable
         """
-
+        # ways a Replaces tag will be added to the PubMed deposit
+        # - is not a poa but was a poa in the past (indicates a version > 1)
+        # - article has a version attribute  > 1
+        # - article has a replaces attribute set to True
         if ((poa_article.is_poa is False and poa_article.was_ever_poa is True)
-            or (poa_article.version and poa_article.version > 1)):
+            or (poa_article.version and poa_article.version > 1)
+            or (hasattr(poa_article, 'replaces') and poa_article.replaces is True)):
             self.replaces = SubElement(parent, 'Replaces')
             self.replaces.set("IdType", "doi")
             self.replaces.text = poa_article.doi

--- a/tests/test_generate_edge_cases.py
+++ b/tests/test_generate_edge_cases.py
@@ -143,5 +143,32 @@ class TestSetCoiStatement(unittest.TestCase):
         self.assertTrue('<CoiStatement>AA, CC No competing interests declared, BB Holds the position of Queen Bee</CoiStatement>' in pubmed_xml_string)
 
 
+class TestReplaces(unittest.TestCase):
+
+    def test_set_replaces(self):
+        """
+        test et_replaces when an article replaces attribute it set
+        """
+        # first test a version 1 with no replaces tag
+        doi = "10.7554/eLife.00666"
+        title = "Test article"
+        article = Article(doi, title)
+        article.version = 1
+        expected = '<Replaces IdType="doi">10.7554/eLife.00666</Replaces>'
+        # generate the PubMed XML
+        pXML = generate.build_pubmed_xml([article])
+        pubmed_xml_string = pXML.output_XML()
+        self.assertIsNotNone(pubmed_xml_string)
+        # expect to not find expected fragment
+        self.assertTrue(expected not in pubmed_xml_string)
+        # second test setting the replaces value on the article object
+        article.replaces = True
+        pXML = generate.build_pubmed_xml([article])
+        pubmed_xml_string = pXML.output_XML()
+        self.assertIsNotNone(pubmed_xml_string)
+        # expect to find expected fragment
+        self.assertTrue(expected in pubmed_xml_string)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add an extra replaces attribute to an article to indicate a <Replaces> tag should be added to the PubMed deposit.

Fixes https://github.com/elifesciences/elife-pubmed-feed/issues/57