### PR TITLE
Fix for when a COI statement ends in a full stop, do not add a commas…

### DIFF
--- a/elifepubmed/generate.py
+++ b/elifepubmed/generate.py
@@ -457,7 +457,7 @@ class PubMedXML(object):
         # concatenate the single conflict of interest statement and add the tag
         if coi_list:
             coi_statement_tag = SubElement(parent, "CoiStatement")
-            coi_statement_tag.text = ', '.join(coi_list)
+            coi_statement_tag.text = utils.join_phrases(coi_list)
 
     def set_object_list(self, parent, poa_article):
         # Keywords and others go in Object tags

--- a/elifepubmed/utils.py
+++ b/elifepubmed/utils.py
@@ -69,3 +69,21 @@ def pubmed_publication_type(article_type, display_channel, types_map):
 def contributor_initials(surname, given_name):
     "a simple author initials format"
     return ''.join([value[0] for value in [given_name, surname] if value is not None])
+
+
+def join_phrases(phrase_list, glue_one=', ', glue_two=' '):
+    "join a list of phrases together with commas unless there is already punctuation"
+    phrase_text = ''
+    for phrase in phrase_list:
+        if not phrase:
+            continue
+        # add a comma if the text does not end in punctuation already
+        if phrase_text != '' and phrase_text.endswith('.'):
+            # join with a space as glue
+            phrase_text = ''.join([phrase_text, glue_two, phrase])
+        elif phrase_text != '':
+            # join with a comma space as glue
+            phrase_text = ''.join([phrase_text, glue_one, phrase])
+        elif phrase_text == '':
+            phrase_text = phrase
+    return phrase_text

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -100,5 +100,11 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(utils.contributor_initials('Ju', None), 'J')
 
 
+    def test_join_phrases(self):
+        "test joining some phrases with punctuation"
+        self.assertEqual(utils.join_phrases([None, None]), '')
+        self.assertEqual(utils.join_phrases(['A', 'B', 'C']), 'A, B, C')
+        self.assertEqual(utils.join_phrases(['A', 'B.', 'C']), 'A, B. C')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
… to the end when concatenating a single string of phrases together.