### PR TITLE
Include PyYAML in install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(
         "elifetools",
         "elifearticle",
         "GitPython",
-        "configparser"
+        "configparser",
+        "PyYAML"
     ],
     url='https://github.com/elifesciences/elife-pubmed-xml-generation',
     maintainer='eLife Sciences Publications Ltd.',


### PR DESCRIPTION
In reference to issue https://github.com/elifesciences/issues/issues/4689

A side-effect, I noticed `PyYAML` library is used, but it is not specified in the library's `setup.py` `install_requires` list, and it should be included.