### PR TITLE
Drop py27 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-git+https://github.com/elifesciences/elife-tools.git@5b57b1798788cc1c56077601df9a66e8de6a0239#egg=elifetools
-git+https://github.com/elifesciences/elife-article.git@99710c213cd81fe6fd1e5c150d6e20efe2d1e33b#egg=elifearticle
+git+https://github.com/elifesciences/elife-tools.git@1ca1de40c9747a2ba25559ec5c5f52f00c1fd85e#egg=elifetools
+git+https://github.com/elifesciences/elife-article.git@158d5d9484aeb22bfb5109a79db3615f8fbe8ab0#egg=elifearticle
 configparser==3.5.0
 PyYAML==4.2b4
 coverage==4.4.2

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,6 @@ setup(
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         ]

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -2,7 +2,6 @@ import unittest
 import time
 import os
 from elifearticle.article import Dataset
-from elifearticle.utils import unicode_value
 from elifepubmed import generate
 from elifepubmed.conf import config, parse_raw_config
 
@@ -15,14 +14,6 @@ generate.TMP_DIR = TEST_BASE_PATH + "tmp" + os.sep
 def read_file_content(file_name):
     with open(file_name, 'rb') as open_file:
         return open_file.read()
-
-
-def unicode_value_safe(string):
-    """call unicode_value with exception catching"""
-    try:
-        return unicode_value(string)
-    except UnicodeDecodeError:
-        return string
 
 
 class TestGenerate(unittest.TestCase):
@@ -58,8 +49,8 @@ class TestGenerate(unittest.TestCase):
             articles = generate.build_articles_for_pubmed(
                 article_xmls=[file_path], config_section=config_section)
             p_xml = generate.build_pubmed_xml(articles, config_section, pub_date, False)
-            pubmed_xml = unicode_value_safe(p_xml.output_xml())
-            model_pubmed_xml = unicode_value_safe(
+            pubmed_xml = str(p_xml.output_xml())
+            model_pubmed_xml = str(
                 read_file_content(TEST_DATA_PATH + pubmed_xml_file))
             self.assertEqual(pubmed_xml, model_pubmed_xml)
             # check the batch_id will be similar to the XML filename
@@ -123,7 +114,7 @@ class TestGenerate(unittest.TestCase):
             article_xmls=[file_path], config_section=config_section)
         # set the is_poa value
         articles[0].is_poa = True
-        pubmed_xml = unicode_value_safe(generate.pubmed_xml(articles, config_section))
+        pubmed_xml = str(generate.pubmed_xml(articles, config_section))
         self.assertTrue('<PubDate PubStatus="aheadofprint">' in pubmed_xml,
                         'aheadofprint date not found in PubMed XML after setting is_poa')
 

--- a/tests/test_generate_edge_cases.py
+++ b/tests/test_generate_edge_cases.py
@@ -1,6 +1,5 @@
 import unittest
 from elifearticle.article import Article, Contributor, FundingAward, RelatedArticle
-from elifearticle.utils import unicode_value
 from elifepubmed import generate
 
 
@@ -17,7 +16,7 @@ class TestGenerateArticleTitle(unittest.TestCase):
         pubmed_xml_string = p_xml.output_xml()
         self.assertIsNotNone(pubmed_xml_string)
         # A quick test just look for the expected string in the output
-        self.assertTrue(expected_title in unicode_value(pubmed_xml_string))
+        self.assertTrue(expected_title in str(pubmed_xml_string))
 
 
 class TestGenerateArticleType(unittest.TestCase):
@@ -34,7 +33,7 @@ class TestGenerateArticleType(unittest.TestCase):
         pubmed_xml_string = p_xml.output_xml()
         self.assertIsNotNone(pubmed_xml_string)
         # A quick test just look for the expected string in the output
-        self.assertTrue(expected_fragment in unicode_value(pubmed_xml_string))
+        self.assertTrue(expected_fragment in str(pubmed_xml_string))
 
     def test_generate_article_type_correction(self):
         "build an article object, set the article_type and related_articles, generate PubMed XML"
@@ -62,7 +61,7 @@ class TestGenerateArticleType(unittest.TestCase):
         self.assertIsNotNone(pubmed_xml_string)
         # A quick test just look for the expected string in the output
         for expected_fragment in expected_fragments:
-            self.assertTrue(expected_fragment in unicode_value(pubmed_xml_string),
+            self.assertTrue(expected_fragment in str(pubmed_xml_string),
                             '{fragment} not found'.format(fragment=expected_fragment))
 
     def test_generate_article_type_retraction(self):
@@ -91,7 +90,7 @@ class TestGenerateArticleType(unittest.TestCase):
         self.assertIsNotNone(pubmed_xml_string)
         # A quick test just look for the expected string in the output
         for expected_fragment in expected_fragments:
-            self.assertTrue(expected_fragment in unicode_value(pubmed_xml_string),
+            self.assertTrue(expected_fragment in str(pubmed_xml_string),
                             '{fragment} not found'.format(fragment=expected_fragment))
 
 
@@ -111,8 +110,8 @@ class TestGenerateArticleContributors(unittest.TestCase):
         pubmed_xml_string = p_xml.output_xml()
         self.assertIsNotNone(pubmed_xml_string)
         # A quick test just look for the expected string in the output
-        self.assertTrue('<AuthorList>' not in unicode_value(pubmed_xml_string))
-        self.assertTrue('<GroupList>' not in unicode_value(pubmed_xml_string))
+        self.assertTrue('<AuthorList>' not in str(pubmed_xml_string))
+        self.assertTrue('<GroupList>' not in str(pubmed_xml_string))
 
     def test_generate_contributor_surname_no_given_name(self):
         "build an article object, set the contributors, generate PubMed XML"
@@ -137,7 +136,7 @@ class TestGenerateArticleContributors(unittest.TestCase):
         pubmed_xml_string = p_xml.output_xml()
         self.assertIsNotNone(pubmed_xml_string)
         # A quick test just look for the expected string in the output
-        self.assertTrue(expected_fragment in unicode_value(pubmed_xml_string))
+        self.assertTrue(expected_fragment in str(pubmed_xml_string))
 
 
 class TestGenerateArticlePOAStatus(unittest.TestCase):
@@ -154,9 +153,9 @@ class TestGenerateArticlePOAStatus(unittest.TestCase):
         pubmed_xml_string = p_xml.output_xml()
         self.assertIsNotNone(pubmed_xml_string)
         # A quick test just look for the expected string in the output
-        self.assertTrue('<Replaces IdType="doi">' in unicode_value(pubmed_xml_string))
+        self.assertTrue('<Replaces IdType="doi">' in str(pubmed_xml_string))
         self.assertTrue('<History><PubDate PubStatus="aheadofprint">' in
-                        unicode_value(pubmed_xml_string))
+                        str(pubmed_xml_string))
 
 
 class TestGenerateArticleIssue(unittest.TestCase):
@@ -176,7 +175,7 @@ class TestGenerateArticleIssue(unittest.TestCase):
         pubmed_xml_string = p_xml.output_xml()
         self.assertIsNotNone(pubmed_xml_string)
         # A quick test just look for the expected string in the output
-        self.assertTrue('<Issue>1</Issue>' in unicode_value(pubmed_xml_string))
+        self.assertTrue('<Issue>1</Issue>' in str(pubmed_xml_string))
 
 
 class TestSetCoiStatement(unittest.TestCase):
@@ -206,7 +205,7 @@ class TestSetCoiStatement(unittest.TestCase):
         expected_fragment = (
             '<CoiStatement>AA, CC No competing interests declared, ' +
             'BB Holds the position of Queen Bee</CoiStatement>')
-        self.assertTrue(expected_fragment in unicode_value(pubmed_xml_string))
+        self.assertTrue(expected_fragment in str(pubmed_xml_string))
 
 
 class TestReplaces(unittest.TestCase):
@@ -226,14 +225,14 @@ class TestReplaces(unittest.TestCase):
         pubmed_xml_string = p_xml.output_xml()
         self.assertIsNotNone(pubmed_xml_string)
         # expect to not find expected fragment
-        self.assertTrue(expected not in unicode_value(pubmed_xml_string))
+        self.assertTrue(expected not in str(pubmed_xml_string))
         # second test setting the replaces value on the article object
         article.replaces = True
         p_xml = generate.build_pubmed_xml([article])
         pubmed_xml_string = p_xml.output_xml()
         self.assertIsNotNone(pubmed_xml_string)
         # expect to find expected fragment
-        self.assertTrue(expected in unicode_value(pubmed_xml_string))
+        self.assertTrue(expected in str(pubmed_xml_string))
 
 
 class TestGenerateArticleFunding(unittest.TestCase):
@@ -253,7 +252,7 @@ class TestGenerateArticleFunding(unittest.TestCase):
         pubmed_xml_string = p_xml.output_xml()
         self.assertIsNotNone(pubmed_xml_string)
         # A quick test just look in a string of the output
-        self.assertTrue('<grant>' not in unicode_value(pubmed_xml_string))
+        self.assertTrue('<grant>' not in str(pubmed_xml_string))
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py27,py35
+envlist = py35
 [testenv]
 deps = -rrequirements.txt
 commands = coverage run -m unittest discover tests


### PR DESCRIPTION
Fixes https://github.com/elifesciences/elife-pubmed-xml-generation/issues/34

Mostly the expected changes, with some tests that relied on unicode value conversion which is now not required in Python 3 only.