### PR TITLE
Refactor setting dataset assigning authority.

### DIFF
--- a/elifepubmed/generate.py
+++ b/elifepubmed/generate.py
@@ -15,13 +15,12 @@ from elifepubmed import utils
 TMP_DIR = 'tmp'
 
 
-ASSIGNING_AUTHORITY_MAP = {
-    'NCBI': [
-        ('www.ncbi.nlm.nih.gov/geo', 'NCBI:geo'),
-        ('www.ncbi.nlm.nih.gov/projects/gap', 'NCBI:dbgap'),
-        ('www.ncbi.nlm.nih.gov/nuccore', 'NCBI:nucleotide'),
-        ('www.ncbi.nlm.nih.gov/sra', 'NCBI:sra')
-        ]
+ASSIGNING_AUTHORITY_URI_MAP = {
+    '10.5061/dryad': 'Dryad',
+    'www.ncbi.nlm.nih.gov/geo': 'NCBI:geo',
+    'www.ncbi.nlm.nih.gov/projects/gap': 'NCBI:dbgap',
+    'www.ncbi.nlm.nih.gov/nuccore': 'NCBI:nucleotide',
+    'www.ncbi.nlm.nih.gov/sra': 'NCBI:sra'
     }
 
 
@@ -625,13 +624,12 @@ def set_grants(parent, poa_article):
                 set_object(parent, "grant", params)
 
 
-def dataset_assigning_authority(assigning_authority, uri):
+def dataset_assigning_authority(uri):
     """precise assigning_authority value considering the uri in some cases"""
-    if ASSIGNING_AUTHORITY_MAP and assigning_authority in ASSIGNING_AUTHORITY_MAP:
-        for hint, new_value in ASSIGNING_AUTHORITY_MAP.get(assigning_authority):
+    if ASSIGNING_AUTHORITY_URI_MAP and uri:
+        for hint, new_value in ASSIGNING_AUTHORITY_URI_MAP.items():
             if hint in uri:
                 return new_value
-    return assigning_authority
 
 
 def dataset_details(dataset):
@@ -642,7 +640,8 @@ def dataset_details(dataset):
     :param dataset: Dataset object
     :returns: string assigning authority of the dataset, string id is the uri or doi
     """
-    assigning_authority = dataset_assigning_authority(dataset.assigning_authority, dataset.uri)
+    assigning_authority = dataset_assigning_authority(
+        etoolsutils.firstnn([dataset.uri, dataset.doi]))
     id_value = etoolsutils.firstnn([dataset.doi, dataset.accession_id])
     return assigning_authority, id_value
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -150,62 +150,52 @@ class TestDataset(unittest.TestCase):
 
     def test_dataset_details_both(self):
         """test Dataset that has both a doi and accession_id"""
-        assigning_authority_value = 'assigning_authority'
+        uri = 'www.ncbi.nlm.nih.gov/geo'
         doi = 'doi'
         accession_id = 'accession_id'
+        expected_authority_value = 'NCBI:geo'
         dataset = Dataset()
+        dataset.uri = uri
         dataset.doi = doi
         dataset.accession_id = accession_id
-        dataset.assigning_authority = assigning_authority_value
         assigning_authority, id_value = generate.dataset_details(dataset)
-        self.assertEqual(assigning_authority, assigning_authority_value)
+        self.assertEqual(assigning_authority, expected_authority_value)
         self.assertEqual(id_value, doi)
 
 
 class TestDatasetAssigningAuthority(unittest.TestCase):
 
-    def test_dataset_assigning_authority(self):
-        """regular assigning authority value"""
-        assigning_authority_value = 'assigning_authority'
-        uri = None
-        assigning_authority = generate.dataset_assigning_authority(assigning_authority_value, uri)
-        self.assertEqual(assigning_authority, assigning_authority_value)
-
     def test_dataset_assigning_authority_none(self):
         """dataset assigning authority when None"""
-        assigning_authority = generate.dataset_assigning_authority(None, None)
+        assigning_authority = generate.dataset_assigning_authority(None)
         self.assertIsNone(assigning_authority)
 
     def test_dataset_assigning_authority_ncbi_geo(self):
         """dataset assigning authority for NCBI geo"""
-        assigning_authority_value = 'NCBI'
         uri = 'https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE48760'
         expected = 'NCBI:geo'
-        assigning_authority = generate.dataset_assigning_authority(assigning_authority_value, uri)
+        assigning_authority = generate.dataset_assigning_authority(uri)
         self.assertEqual(assigning_authority, expected)
 
     def test_dataset_assigning_authority_ncbi_dbgap(self):
         """NCBI dbgap"""
-        assigning_authority_value = 'NCBI'
         uri = 'https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001660.v1.p1'
         expected = 'NCBI:dbgap'
-        assigning_authority = generate.dataset_assigning_authority(assigning_authority_value, uri)
+        assigning_authority = generate.dataset_assigning_authority(uri)
         self.assertEqual(assigning_authority, expected)
 
     def test_dataset_assigning_authority_ncbi_nucleotide(self):
         """NCBI nucleotide"""
-        assigning_authority_value = 'NCBI'
         uri = 'https://www.ncbi.nlm.nih.gov/nuccore/KY616976'
         expected = 'NCBI:nucleotide'
-        assigning_authority = generate.dataset_assigning_authority(assigning_authority_value, uri)
+        assigning_authority = generate.dataset_assigning_authority(uri)
         self.assertEqual(assigning_authority, expected)
 
     def test_dataset_assigning_authority_ncbi_sra(self):
         """NCBI sra"""
-        assigning_authority_value = 'NCBI'
         uri = 'https://www.ncbi.nlm.nih.gov/sra/?term=SRA012474'
         expected = 'NCBI:sra'
-        assigning_authority = generate.dataset_assigning_authority(assigning_authority_value, uri)
+        assigning_authority = generate.dataset_assigning_authority(uri)
         self.assertEqual(assigning_authority, expected)
 
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/schematron-gitbook/issues/123

As a short-term transition, do not expect to find an `assigning-authority` value for a dataset when determining its PubMed dataset object type.

In future the plan will be to only rely on the dataset's `<source>` value from the XML file, possibly falling back on this `uri` value matching, or the `uri` matching logic will be removed.