### PR TITLE
Use pretty XML in test fixtures.

### DIFF
--- a/elifepubmed/generate.py
+++ b/elifepubmed/generate.py
@@ -763,16 +763,18 @@ def build_pubmed_xml(poa_articles, config_section="elife", pub_date=None, add_co
     return PubMedXML(poa_articles, pubmed_config, pub_date, add_comment)
 
 
-def pubmed_xml(poa_articles, config_section="elife", pub_date=None, add_comment=True):
+def pubmed_xml(poa_articles, config_section="elife", pub_date=None, add_comment=True,
+               pretty=False):
     "build PubMed xml and return output as a string"
     p_xml = build_pubmed_xml(poa_articles, config_section, pub_date, add_comment)
-    return p_xml.output_xml()
+    return p_xml.output_xml(pretty=pretty)
 
 
-def pubmed_xml_to_disk(poa_articles, config_section="elife", pub_date=None, add_comment=True):
+def pubmed_xml_to_disk(poa_articles, config_section="elife", pub_date=None, add_comment=True,
+                       pretty=False):
     "build pubmed xml and write the output to disk"
     p_xml = build_pubmed_xml(poa_articles, config_section, pub_date, add_comment)
-    xml_string = p_xml.output_xml()
+    xml_string = p_xml.output_xml(pretty=pretty)
     # Write to file
     filename = TMP_DIR + os.sep + p_xml.batch_id + '.xml'
     with open(filename, "wb") as open_file:

--- a/generate_test_fixtures.py
+++ b/generate_test_fixtures.py
@@ -17,4 +17,4 @@ if __name__ == '__main__':
         generate.TMP_DIR = 'tests/test_data'
         articles = generate.build_articles_for_pubmed(
             article_xmls=[xml_file], config_section=config_section)
-        generate.pubmed_xml_to_disk(articles, config_section, pub_date, add_comment)
+        generate.pubmed_xml_to_disk(articles, config_section, pub_date, add_comment, pretty=True)

--- a/tests/test_data/elife-pubmed-00003-20170717071707.xml
+++ b/tests/test_data/elife-pubmed-00003-20170717071707.xml
@@ -1,1 +1,136 @@
-<?xml version="1.0" encoding="utf-8"?><!DOCTYPE ArticleSet PUBLIC "-//NLM//DTD PubMed 2.7//EN"  "https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd"><ArticleSet><Article><Journal><PublisherName>eLife Sciences Publications, Ltd</PublisherName><JournalTitle>eLife</JournalTitle><Issn>2050-084X</Issn><Volume>1</Volume><PubDate PubStatus="aheadofprint"><Year>2012</Year><Month>November</Month><Day>13</Day></PubDate></Journal><ArticleTitle>This, 'title, includes &quot;quotation&quot;, marks &amp; more ü</ArticleTitle><ELocationID EIdType="doi">10.7554/eLife.00003</ELocationID><ELocationID EIdType="pii">e00003</ELocationID><Language>EN</Language><AuthorList><Author><FirstName>Preetha</FirstName><LastName>Anand</LastName><Affiliation>Dev. and Cell Bio, UC Irvine, Irvine, United States</Affiliation></Author><Author><FirstName>Silvia</FirstName><LastName>Cermelli</LastName><Affiliation>DPH, Fred Hutchinson Cancer Research Center, Washington, United States</Affiliation></Author><Author><FirstName>Zhihuan</FirstName><LastName>Li</LastName><Affiliation>Biology, U. Rochester, Rochester, United States</Affiliation></Author><Author><FirstName>Adam</FirstName><LastName>Kassan</LastName><Affiliation>Equip de Proliferació i Senyalització Cellular, Institut d'Investigacions Biomèdiques August Pi i Sunyer (IDIBAPS)., Barcelona, Spain</Affiliation></Author><Author><FirstName>Marta</FirstName><LastName>Bosch</LastName><Affiliation>Equip de Proliferació i Senyalització Cellular, Institut d'Investigacions Biomèdiques August Pi i Sunyer (IDIBAPS)., Barcelona, Spain</Affiliation></Author><Author><FirstName>Robilyn</FirstName><LastName>Sigua</LastName><Affiliation>Dev. and Cell Biology, UC Irvine, Irvine, United States</Affiliation></Author><Author><FirstName>Lan</FirstName><LastName>Huang</LastName><Affiliation>Physiology and Biophysics, UC Irvine, Irvine, United States</Affiliation></Author><Author><FirstName>Andre J</FirstName><LastName>Ouellette</LastName><Affiliation>Dept. Pathology &amp; Lab Medicine, USC, Los Angeles, United States</Affiliation></Author><Author><FirstName>Albert</FirstName><LastName>Pol</LastName><Affiliation>Equip de Proliferació i Senyalització Cellular, Institut d'Investigacions Biomèdiques August Pi i Sunyer (IDIBAPS)., Barcelona, Spain</Affiliation></Author><Author><FirstName>Michael A</FirstName><LastName>Welte</LastName><Affiliation>Department of Biology, U. Rochester, Rochester, United States</Affiliation></Author><Author><FirstName>Steven P</FirstName><LastName>Gross</LastName><Affiliation>Developmental and Cell Biology, University of California, Irvine, Irvine, United States</Affiliation></Author><Author><FirstName EmptyYN="Y"/><LastName>SurnameOnly</LastName><Affiliation>Developmental and Cell Biology, University of California, Irvine, Irvine, United States</Affiliation></Author></AuthorList><PublicationType>Journal Article</PublicationType><ArticleIdList><ArticleId IdType="doi">10.7554/eLife.00003</ArticleId><ArticleId IdType="pii">00003</ArticleId></ArticleIdList><History><PubDate PubStatus="received"><Year>2012</Year><Month>06</Month><Day>20</Day></PubDate><PubDate PubStatus="accepted"><Year>2012</Year><Month>09</Month><Day>05</Day></PubDate></History><Abstract><AbstractText Label="">This abstract includes <i>PINK1</i> &amp; <i>parkin</i> &lt; 20 &gt; 10</AbstractText></Abstract><CopyrightInformation>© 2012, Anand et al</CopyrightInformation><CoiStatement>PA, SC, ZL, AK, MB, RS, LH, AO, AP, MW, SG, S The authors declare that no competing interests exist.</CoiStatement><ObjectList><Object Type="keyword"><Param Name="value">B. subtilis</Param></Object><Object Type="keyword"><Param Name="value">D. melanogaster</Param></Object><Object Type="keyword"><Param Name="value">E. coli</Param></Object><Object Type="keyword"><Param Name="value">mouse</Param></Object><Object Type="keyword"><Param Name="value">immunology</Param></Object><Object Type="keyword"><Param Name="value">microbiology</Param></Object><Object Type="keyword"><Param Name="value">infectious disease</Param></Object></ObjectList></Article></ArticleSet>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE ArticleSet
+ PUBLIC "-//NLM//DTD PubMed 2.7//EN"
+  "https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd">
+<ArticleSet>
+<Article>
+<Journal>
+<PublisherName>eLife Sciences Publications, Ltd</PublisherName>
+<JournalTitle>eLife</JournalTitle>
+<Issn>2050-084X</Issn>
+<Volume>1</Volume>
+<PubDate PubStatus="aheadofprint">
+<Year>2012</Year>
+<Month>November</Month>
+<Day>13</Day>
+</PubDate>
+</Journal>
+<ArticleTitle>This, 'title, includes &quot;quotation&quot;, marks &amp; more ü</ArticleTitle>
+<ELocationID EIdType="doi">10.7554/eLife.00003</ELocationID>
+<ELocationID EIdType="pii">e00003</ELocationID>
+<Language>EN</Language>
+<AuthorList>
+<Author>
+<FirstName>Preetha</FirstName>
+<LastName>Anand</LastName>
+<Affiliation>Dev. and Cell Bio, UC Irvine, Irvine, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>Silvia</FirstName>
+<LastName>Cermelli</LastName>
+<Affiliation>DPH, Fred Hutchinson Cancer Research Center, Washington, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>Zhihuan</FirstName>
+<LastName>Li</LastName>
+<Affiliation>Biology, U. Rochester, Rochester, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>Adam</FirstName>
+<LastName>Kassan</LastName>
+<Affiliation>Equip de Proliferació i Senyalització Cellular, Institut d'Investigacions Biomèdiques August Pi i Sunyer (IDIBAPS)., Barcelona, Spain</Affiliation>
+</Author>
+<Author>
+<FirstName>Marta</FirstName>
+<LastName>Bosch</LastName>
+<Affiliation>Equip de Proliferació i Senyalització Cellular, Institut d'Investigacions Biomèdiques August Pi i Sunyer (IDIBAPS)., Barcelona, Spain</Affiliation>
+</Author>
+<Author>
+<FirstName>Robilyn</FirstName>
+<LastName>Sigua</LastName>
+<Affiliation>Dev. and Cell Biology, UC Irvine, Irvine, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>Lan</FirstName>
+<LastName>Huang</LastName>
+<Affiliation>Physiology and Biophysics, UC Irvine, Irvine, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>Andre J</FirstName>
+<LastName>Ouellette</LastName>
+<Affiliation>Dept. Pathology &amp; Lab Medicine, USC, Los Angeles, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>Albert</FirstName>
+<LastName>Pol</LastName>
+<Affiliation>Equip de Proliferació i Senyalització Cellular, Institut d'Investigacions Biomèdiques August Pi i Sunyer (IDIBAPS)., Barcelona, Spain</Affiliation>
+</Author>
+<Author>
+<FirstName>Michael A</FirstName>
+<LastName>Welte</LastName>
+<Affiliation>Department of Biology, U. Rochester, Rochester, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>Steven P</FirstName>
+<LastName>Gross</LastName>
+<Affiliation>Developmental and Cell Biology, University of California, Irvine, Irvine, United States</Affiliation>
+</Author>
+<Author>
+<FirstName EmptyYN="Y"/>
+<LastName>SurnameOnly</LastName>
+<Affiliation>Developmental and Cell Biology, University of California, Irvine, Irvine, United States</Affiliation>
+</Author>
+</AuthorList>
+<PublicationType>Journal Article</PublicationType>
+<ArticleIdList>
+<ArticleId IdType="doi">10.7554/eLife.00003</ArticleId>
+<ArticleId IdType="pii">00003</ArticleId>
+</ArticleIdList>
+<History>
+<PubDate PubStatus="received">
+<Year>2012</Year>
+<Month>06</Month>
+<Day>20</Day>
+</PubDate>
+<PubDate PubStatus="accepted">
+<Year>2012</Year>
+<Month>09</Month>
+<Day>05</Day>
+</PubDate>
+</History>
+<Abstract>
+<AbstractText Label="">
+This abstract includes 
+<i>PINK1</i>
+ &amp; 
+<i>parkin</i>
+ &lt; 20 &gt; 10
+</AbstractText>
+</Abstract>
+<CopyrightInformation>© 2012, Anand et al</CopyrightInformation>
+<CoiStatement>PA, SC, ZL, AK, MB, RS, LH, AO, AP, MW, SG, S The authors declare that no competing interests exist.</CoiStatement>
+<ObjectList>
+<Object Type="keyword">
+<Param Name="value">B. subtilis</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">D. melanogaster</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">E. coli</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">mouse</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">immunology</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">microbiology</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">infectious disease</Param>
+</Object>
+</ObjectList>
+</Article>
+</ArticleSet>

--- a/tests/test_data/elife-pubmed-00666-20170717071707.xml
+++ b/tests/test_data/elife-pubmed-00666-20170717071707.xml
@@ -1,12 +1,200 @@
-<?xml version="1.0" encoding="utf-8"?><!DOCTYPE ArticleSet PUBLIC "-//NLM//DTD PubMed 2.7//EN"  "https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd"><ArticleSet><Article><Journal><PublisherName>eLife Sciences Publications, Ltd</PublisherName><JournalTitle>eLife</JournalTitle><Issn>2050-084X</Issn><Volume>5</Volume><PubDate PubStatus="epublish"><Year>2016</Year><Month>April</Month><Day>25</Day></PubDate></Journal><ArticleTitle>The eLife research article</ArticleTitle><ELocationID EIdType="doi">10.7554/eLife.00666</ELocationID><ELocationID EIdType="pii">e00666</ELocationID><Language>EN</Language><AuthorList><Author EqualContrib="Y"><FirstName>Melissa</FirstName><LastName>Harrison</LastName><Suffix>Jnr</Suffix><Affiliation>Department of Production, eLife, Cambridge, United Kingdom</Affiliation><Identifier Source="ORCID">https://orcid.org/0000-0003-3523-4408</Identifier></Author><Author EqualContrib="Y"><FirstName>James F</FirstName><LastName>Gilbert</LastName><Affiliation>Department of Production, eLife, Cambridge, United Kingdom</Affiliation></Author><Author EqualContrib="Y"><CollectiveName>eLife Editorial Production Group</CollectiveName><Affiliation>Department of Production, eLife, Cambridge, United Kingdom</Affiliation></Author><Author EqualContrib="Y"><CollectiveName>eLife Technology Group</CollectiveName><Affiliation>Department of Technology, eLife, Cambridge, United Kingdom</Affiliation></Author></AuthorList><GroupList><Group><GroupName>eLife Editorial Production Group</GroupName><IndividualName><FirstName>Alistair</FirstName><LastName>Shearer</LastName></IndividualName><IndividualName><FirstName>Hannah</FirstName><LastName>Caton</LastName></IndividualName><IndividualName><FirstName>Wei Mun</FirstName><LastName>Chan</LastName></IndividualName><IndividualName><FirstName>Hannah</FirstName><LastName>Drury</LastName></IndividualName><IndividualName><FirstName>Maria</FirstName><LastName>Guerreiro</LastName></IndividualName><IndividualName><FirstName>Susanna</FirstName><LastName>Richmond</LastName></IndividualName></Group><Group><GroupName>eLife Technology Group</GroupName><IndividualName><FirstName>Graham</FirstName><LastName>Nott</LastName></IndividualName><IndividualName><FirstName>Chris</FirstName><LastName>Wilkinson</LastName></IndividualName><IndividualName><FirstName>Luke</FirstName><LastName>Skibinski</LastName></IndividualName></Group><Group><GroupName>for the eLife Staff Team</GroupName><IndividualName><FirstName EmptyYN="Y"/><LastName>for the eLife Staff Team</LastName></IndividualName></Group></GroupList><PublicationType>Journal Article</PublicationType><ArticleIdList><ArticleId IdType="doi">10.7554/eLife.00666</ArticleId><ArticleId IdType="pii">00666</ArticleId></ArticleIdList><History><PubDate PubStatus="received"><Year>2016</Year><Month>03</Month><Day>01</Day></PubDate><PubDate PubStatus="accepted"><Year>2016</Year><Month>04</Month><Day>01</Day></PubDate></History><Abstract><AbstractText Label="">This is the abstract. This article will describe the eLife article and the process.
-                    An abstract can contain any formatting, such as <i>italics</i>,
-                        <b>bold</b>, <sup>superscript</sup>, <sub>subscript</sub> or small caps. MathML is
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE ArticleSet
+ PUBLIC "-//NLM//DTD PubMed 2.7//EN"
+  "https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd">
+<ArticleSet>
+<Article>
+<Journal>
+<PublisherName>eLife Sciences Publications, Ltd</PublisherName>
+<JournalTitle>eLife</JournalTitle>
+<Issn>2050-084X</Issn>
+<Volume>5</Volume>
+<PubDate PubStatus="epublish">
+<Year>2016</Year>
+<Month>April</Month>
+<Day>25</Day>
+</PubDate>
+</Journal>
+<ArticleTitle>The eLife research article</ArticleTitle>
+<ELocationID EIdType="doi">10.7554/eLife.00666</ELocationID>
+<ELocationID EIdType="pii">e00666</ELocationID>
+<Language>EN</Language>
+<AuthorList>
+<Author EqualContrib="Y">
+<FirstName>Melissa</FirstName>
+<LastName>Harrison</LastName>
+<Suffix>Jnr</Suffix>
+<Affiliation>Department of Production, eLife, Cambridge, United Kingdom</Affiliation>
+<Identifier Source="ORCID">https://orcid.org/0000-0003-3523-4408</Identifier>
+</Author>
+<Author EqualContrib="Y">
+<FirstName>James F</FirstName>
+<LastName>Gilbert</LastName>
+<Affiliation>Department of Production, eLife, Cambridge, United Kingdom</Affiliation>
+</Author>
+<Author EqualContrib="Y">
+<CollectiveName>eLife Editorial Production Group</CollectiveName>
+<Affiliation>Department of Production, eLife, Cambridge, United Kingdom</Affiliation>
+</Author>
+<Author EqualContrib="Y">
+<CollectiveName>eLife Technology Group</CollectiveName>
+<Affiliation>Department of Technology, eLife, Cambridge, United Kingdom</Affiliation>
+</Author>
+</AuthorList>
+<GroupList>
+<Group>
+<GroupName>eLife Editorial Production Group</GroupName>
+<IndividualName>
+<FirstName>Alistair</FirstName>
+<LastName>Shearer</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Hannah</FirstName>
+<LastName>Caton</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Wei Mun</FirstName>
+<LastName>Chan</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Hannah</FirstName>
+<LastName>Drury</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Maria</FirstName>
+<LastName>Guerreiro</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Susanna</FirstName>
+<LastName>Richmond</LastName>
+</IndividualName>
+</Group>
+<Group>
+<GroupName>eLife Technology Group</GroupName>
+<IndividualName>
+<FirstName>Graham</FirstName>
+<LastName>Nott</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Chris</FirstName>
+<LastName>Wilkinson</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Luke</FirstName>
+<LastName>Skibinski</LastName>
+</IndividualName>
+</Group>
+<Group>
+<GroupName>for the eLife Staff Team</GroupName>
+<IndividualName>
+<FirstName EmptyYN="Y"/>
+<LastName>for the eLife Staff Team</LastName>
+</IndividualName>
+</Group>
+</GroupList>
+<PublicationType>Journal Article</PublicationType>
+<ArticleIdList>
+<ArticleId IdType="doi">10.7554/eLife.00666</ArticleId>
+<ArticleId IdType="pii">00666</ArticleId>
+</ArticleIdList>
+<History>
+<PubDate PubStatus="received">
+<Year>2016</Year>
+<Month>03</Month>
+<Day>01</Day>
+</PubDate>
+<PubDate PubStatus="accepted">
+<Year>2016</Year>
+<Month>04</Month>
+<Day>01</Day>
+</PubDate>
+</History>
+<Abstract>
+<AbstractText Label="">
+This is the abstract. This article will describe the eLife article and the process.
+                    An abstract can contain any formatting, such as 
+<i>italics</i>
+,
+                        
+<b>bold</b>
+, 
+<sup>superscript</sup>
+, 
+<sub>subscript</sub>
+ or small caps. MathML is
                     also allowed: 
                     [Formula: see text]
-                .</AbstractText><AbstractText Label="">eLife does not structure abstracts into sub headings expect in a clinical trial article, but the abstract can have
+                .
+</AbstractText>
+<AbstractText Label="">eLife does not structure abstracts into sub headings expect in a clinical trial article, but the abstract can have
                     multiple paragarahs. The sub DOI is always .001 as it is the first asset in any
-                    article. I have added an unmatched &gt; bracket as this has been an issue for PubMed deposits in the past.</AbstractText><AbstractText Label="">If this was a clinical trial the clinical trial details would be listed at the end of the abstract:</AbstractText><AbstractText Label="">Clinical trial Registration: EudraCT2004-000446-20.</AbstractText></Abstract><OtherAbstract Language="eng" Type="plain-language-summary">eLife digest are now optional and not every research article will contain one.
+                    article. I have added an unmatched &gt; bracket as this has been an issue for PubMed deposits in the past.</AbstractText>
+<AbstractText Label="">If this was a clinical trial the clinical trial details would be listed at the end of the abstract:</AbstractText>
+<AbstractText Label="">Clinical trial Registration: EudraCT2004-000446-20.</AbstractText>
+</Abstract>
+<OtherAbstract Language="eng" Type="plain-language-summary">eLife digest are now optional and not every research article will contain one.
                     These are layman abstracts, designed for non-specialists in this field to be
-                    able to understand this article, as well as the general public. Here is paragraph 2 of the digest.</OtherAbstract><CopyrightInformation>© 2016, Harrison et al</CopyrightInformation><CoiStatement>MH Chair of JATS4R, JG No competing interests declared,  Graham Nott is not an eLife employee</CoiStatement><ObjectList><Object Type="keyword"><Param Name="value">human</Param></Object><Object Type="keyword"><Param Name="value">machine</Param></Object><Object Type="keyword"><Param Name="value">cell biology</Param></Object><Object Type="keyword"><Param Name="value">plant biology</Param></Object><Object Type="keyword"><Param Name="value">XML</Param></Object><Object Type="keyword"><Param Name="value">Housestyle</Param></Object><Object Type="keyword"><Param Name="value">eLife</Param></Object><Object Type="keyword"><Param Name="value">
+                    able to understand this article, as well as the general public. Here is paragraph 2 of the digest.</OtherAbstract>
+<CopyrightInformation>© 2016, Harrison et al</CopyrightInformation>
+<CoiStatement>MH Chair of JATS4R, JG No competing interests declared,  Graham Nott is not an eLife employee</CoiStatement>
+<ObjectList>
+<Object Type="keyword">
+<Param Name="value">human</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">machine</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">cell biology</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">plant biology</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">XML</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">Housestyle</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">eLife</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">
 formatting
-</Param></Object><Object Type="grant"><Param Name="id">F32 GM089018</Param><Param Name="grantor">Howard Hughes Medical Institute</Param></Object><Object Type="Dryad"><Param Name="id">10.5061/dryad.kj1f3v4</Param></Object><Object Type="NCBI:geo"><Param Name="id">GSE48760</Param></Object><Object Type="NCBI:geo"><Param Name="id">GSE44902</Param></Object><Object Type="PDB"><Param Name="id">10.2210/pdb4qen/pdb</Param></Object><Object Type="NCBI:nucleotide"><Param Name="id">NM_009324</Param></Object><Object Type="NCBI:geo"><Param Name="id">GSE70542</Param></Object><Object Type="Dryad"><Param Name="id">10.5061/dryad.cv323</Param></Object><Object Type="BioProject"><Param Name="id">PRJEB2846</Param></Object><Object Type="BioProject"><Param Name="id">PRJEB2460</Param></Object></ObjectList></Article></ArticleSet>
+</Param>
+</Object>
+<Object Type="grant">
+<Param Name="id">F32 GM089018</Param>
+<Param Name="grantor">Howard Hughes Medical Institute</Param>
+</Object>
+<Object Type="Dryad">
+<Param Name="id">10.5061/dryad.kj1f3v4</Param>
+</Object>
+<Object Type="NCBI:geo">
+<Param Name="id">GSE48760</Param>
+</Object>
+<Object Type="NCBI:geo">
+<Param Name="id">GSE44902</Param>
+</Object>
+<Object Type="PDB">
+<Param Name="id">10.2210/pdb4qen/pdb</Param>
+</Object>
+<Object Type="NCBI:nucleotide">
+<Param Name="id">NM_009324</Param>
+</Object>
+<Object Type="NCBI:geo">
+<Param Name="id">GSE70542</Param>
+</Object>
+<Object Type="Dryad">
+<Param Name="id">10.5061/dryad.cv323</Param>
+</Object>
+<Object Type="BioProject">
+<Param Name="id">PRJEB2846</Param>
+</Object>
+<Object Type="BioProject">
+<Param Name="id">PRJEB2460</Param>
+</Object>
+</ObjectList>
+</Article>
+</ArticleSet>

--- a/tests/test_data/elife-pubmed-02935-20170717071707.xml
+++ b/tests/test_data/elife-pubmed-02935-20170717071707.xml
@@ -1,1 +1,974 @@
-<?xml version="1.0" encoding="utf-8"?><!DOCTYPE ArticleSet PUBLIC "-//NLM//DTD PubMed 2.7//EN"  "https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd"><ArticleSet><Article><Journal><PublisherName>eLife Sciences Publications, Ltd</PublisherName><JournalTitle>eLife</JournalTitle><Issn>2050-084X</Issn><Volume>3</Volume><PubDate PubStatus="epublish"><Year>2014</Year><Month>October</Month><Day>01</Day></PubDate></Journal><Replaces IdType="doi">10.7554/eLife.02935</Replaces><ArticleTitle>Origins and functional consequences of somatic mitochondrial DNA mutations in human cancer</ArticleTitle><ELocationID EIdType="doi">10.7554/eLife.02935</ELocationID><ELocationID EIdType="pii">e02935</ELocationID><Language>EN</Language><AuthorList><Author><FirstName>Young Seok</FirstName><LastName>Ju</LastName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><FirstName>Ludmil B</FirstName><LastName>Alexandrov</LastName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><FirstName>Moritz</FirstName><LastName>Gerstung</LastName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><FirstName>Inigo</FirstName><LastName>Martincorena</LastName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><FirstName>Serena</FirstName><LastName>Nik-Zainal</LastName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><FirstName>Manasa</FirstName><LastName>Ramakrishna</LastName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><FirstName>Helen R</FirstName><LastName>Davies</LastName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><FirstName>Elli</FirstName><LastName>Papaemmanuil</LastName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><FirstName>Gunes</FirstName><LastName>Gundem</LastName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><FirstName>Adam</FirstName><LastName>Shlien</LastName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><FirstName>Niccolo</FirstName><LastName>Bolli</LastName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><FirstName>Sam</FirstName><LastName>Behjati</LastName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><FirstName>Patrick S</FirstName><LastName>Tarpey</LastName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><FirstName>Jyoti</FirstName><LastName>Nangalia</LastName><AffiliationInfo><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</Affiliation></AffiliationInfo></Author><Author><FirstName>Charles E</FirstName><LastName>Massie</LastName><AffiliationInfo><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</Affiliation></AffiliationInfo></Author><Author><FirstName>Adam P</FirstName><LastName>Butler</LastName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><FirstName>Jon W</FirstName><LastName>Teague</LastName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><FirstName>George S</FirstName><LastName>Vassiliou</LastName><AffiliationInfo><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</Affiliation></AffiliationInfo></Author><Author><FirstName>Anthony R</FirstName><LastName>Green</LastName><AffiliationInfo><Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</Affiliation></AffiliationInfo></Author><Author><FirstName>Ming-Qing</FirstName><LastName>Du</LastName><Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation></Author><Author><FirstName>Ashwin</FirstName><LastName>Unnikrishnan</LastName><Affiliation>Lowy Cancer Research Centre, University of New South Wales, Sydney, Australia</Affiliation></Author><Author><FirstName>John E</FirstName><LastName>Pimanda</LastName><Affiliation>Lowy Cancer Research Centre, University of New South Wales, Sydney, Australia</Affiliation></Author><Author><FirstName>Bin Tean</FirstName><LastName>Teh</LastName><AffiliationInfo><Affiliation>Laboratory of Cancer Epigenome, National Cancer Centre, Singapore, Singapore</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Duke-NUS Graduate Medical School, Singapore, Singapore</Affiliation></AffiliationInfo></Author><Author><FirstName>Nikhil</FirstName><LastName>Munshi</LastName><Affiliation>Department of Hematologic Oncology, Dana-Farber Cancer Institute, Boston, United States</Affiliation></Author><Author><FirstName>Mel</FirstName><LastName>Greaves</LastName><Affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</Affiliation></Author><Author><FirstName>Paresh</FirstName><LastName>Vyas</LastName><Affiliation>Weatherall Institute for Molecular Medicine, University of Oxford, Oxford, United Kingdom</Affiliation></Author><Author><FirstName>Adel K</FirstName><LastName>El-Naggar</LastName><Affiliation>Department of Pathology, MD Anderson Cancer Center, Houston, United States</Affiliation></Author><Author><FirstName>Tom</FirstName><LastName>Santarius</LastName><Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation></Author><Author><FirstName>V Peter</FirstName><LastName>Collins</LastName><Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation></Author><Author><FirstName>Richard</FirstName><LastName>Grundy</LastName><Affiliation>Children's Brain Tumour Research Centre, University of Nottingham, Nottingham, United Kingdom</Affiliation></Author><Author><FirstName>Jack A</FirstName><LastName>Taylor</LastName><Affiliation>National Institute of Environmental Health Sciences, National Institute of Health, Triangle, North Carolina, United States</Affiliation></Author><Author><FirstName>D Neil</FirstName><LastName>Hayes</LastName><Affiliation>Department of Internal Medicine, University of North Carolina, Chapel Hill, United States</Affiliation></Author><Author><FirstName>David</FirstName><LastName>Malkin</LastName><Affiliation>Hospital for Sick Children, University of Toronto, Toronto, Canada</Affiliation></Author><Author><CollectiveName>ICGC Breast Cancer Group</CollectiveName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><CollectiveName>ICGC Chronic Myeloid Disorders Group</CollectiveName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><CollectiveName>ICGC Prostate Cancer Group</CollectiveName><AffiliationInfo><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Cancer Research UK Cambridge Institute, University of Cambridge, Cambridge, United Kingdom</Affiliation></AffiliationInfo></Author><Author><FirstName>Christopher S</FirstName><LastName>Foster</LastName><AffiliationInfo><Affiliation>Department of Molecular and Clinical Cancer Medicine, University of Liverpool, London, United Kingdom</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>HCA Pathology Laboratories, London, United Kingdom</Affiliation></AffiliationInfo></Author><Author><FirstName>Anne Y</FirstName><LastName>Warren</LastName><Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation></Author><Author><FirstName>Hayley C</FirstName><LastName>Whitaker</LastName><Affiliation>Cancer Research UK Cambridge Institute, University of Cambridge, Cambridge, United Kingdom</Affiliation></Author><Author><FirstName>Daniel</FirstName><LastName>Brewer</LastName><AffiliationInfo><Affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>School of Biological Sciences, University of East Anglia, Norwich, United Kingdom</Affiliation></AffiliationInfo></Author><Author><FirstName>Rosalind</FirstName><LastName>Eeles</LastName><Affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</Affiliation></Author><Author><FirstName>Colin</FirstName><LastName>Cooper</LastName><AffiliationInfo><Affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>School of Biological Sciences, University of East Anglia, Norwich, United Kingdom</Affiliation></AffiliationInfo></Author><Author><FirstName>David</FirstName><LastName>Neal</LastName><Affiliation>Cancer Research UK Cambridge Institute, University of Cambridge, Cambridge, United Kingdom</Affiliation></Author><Author><FirstName>Tapio</FirstName><LastName>Visakorpi</LastName><Affiliation>Institute of Biosciences and Medical Technology - BioMediTech and Fimlab Laboratories, University of Tampere and Tampere University Hospital, Tampere, Finland</Affiliation></Author><Author><FirstName>William B</FirstName><LastName>Isaacs</LastName><Affiliation>Department of Oncology, Johns Hopkins University, Baltimore, United States</Affiliation></Author><Author><FirstName>G Steven</FirstName><LastName>Bova</LastName><Affiliation>Institute of Biosciences and Medical Technology - BioMediTech and Fimlab Laboratories, University of Tampere and Tampere University Hospital, Tampere, Finland</Affiliation></Author><Author><FirstName>Adrienne M</FirstName><LastName>Flanagan</LastName><AffiliationInfo><Affiliation>Department of Histopathology, Royal National Orthopaedic Hospital, Middlesex, United Kingdom</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>University College London Cancer Institute, University College London, London, United Kingdom</Affiliation></AffiliationInfo></Author><Author><FirstName>P Andrew</FirstName><LastName>Futreal</LastName><AffiliationInfo><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Department of Genomic Medicine, The University of Texas, MD Anderson Cancer Center, Houston, Texas, United States</Affiliation></AffiliationInfo></Author><Author><FirstName>Andy G</FirstName><LastName>Lynch</LastName><Affiliation>Cancer Research UK Cambridge Institute, University of Cambridge, Cambridge, United Kingdom</Affiliation></Author><Author><FirstName>Patrick F</FirstName><LastName>Chinnery</LastName><Affiliation>Wellcome Trust Centre for Mitochondrial Research, Institute of Genetic Medicine, Newcastle University, Newcastle-upon-tyne, United Kingdom</Affiliation></Author><Author><FirstName>Ultan</FirstName><LastName>McDermott</LastName><AffiliationInfo><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation></AffiliationInfo></Author><Author><FirstName>Michael R</FirstName><LastName>Stratton</LastName><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></Author><Author><FirstName>Peter J</FirstName><LastName>Campbell</LastName><AffiliationInfo><Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation></AffiliationInfo><AffiliationInfo><Affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</Affiliation></AffiliationInfo></Author></AuthorList><GroupList><Group><GroupName>ICGC Breast Cancer Group</GroupName><IndividualName><FirstName>Elena</FirstName><LastName>Provenzano</LastName></IndividualName><IndividualName><FirstName>Marc</FirstName><LastName>van de Vijver</LastName></IndividualName><IndividualName><FirstName>Andrea L</FirstName><LastName>Richardson</LastName></IndividualName><IndividualName><FirstName>Colin</FirstName><LastName>Purdie</LastName></IndividualName><IndividualName><FirstName>Sarah</FirstName><LastName>Pinder</LastName></IndividualName><IndividualName><FirstName>Gaetan</FirstName><LastName>MacGrogan</LastName></IndividualName><IndividualName><FirstName>Anne</FirstName><LastName>Vincent-Salomon</LastName></IndividualName><IndividualName><FirstName>Denis</FirstName><LastName>Larsimont</LastName></IndividualName><IndividualName><FirstName>Dorthe</FirstName><LastName>Grabau</LastName></IndividualName><IndividualName><FirstName>Torill</FirstName><LastName>Sauer</LastName></IndividualName><IndividualName><FirstName>Øystein</FirstName><LastName>Garred</LastName></IndividualName><IndividualName><FirstName>Anna</FirstName><LastName>Ehinger</LastName></IndividualName><IndividualName><FirstName>Gert G</FirstName><LastName>Van den Eynden</LastName></IndividualName><IndividualName><FirstName>C.H.M.</FirstName><LastName>van Deurzen</LastName></IndividualName><IndividualName><FirstName>Roberto</FirstName><LastName>Salgado</LastName></IndividualName><IndividualName><FirstName>Jane E</FirstName><LastName>Brock</LastName></IndividualName><IndividualName><FirstName>Sunil R</FirstName><LastName>Lakhani</LastName></IndividualName><IndividualName><FirstName>Dilip D</FirstName><LastName>Giri</LastName></IndividualName><IndividualName><FirstName>Laurent</FirstName><LastName>Arnould</LastName></IndividualName><IndividualName><FirstName>Jocelyne</FirstName><LastName>Jacquemier</LastName></IndividualName><IndividualName><FirstName>Isabelle</FirstName><LastName>Treilleux</LastName></IndividualName><IndividualName><FirstName>Carlos</FirstName><LastName>Caldas</LastName></IndividualName><IndividualName><FirstName>Suet-Feung</FirstName><LastName>Chin</LastName></IndividualName><IndividualName><FirstName>Aquila</FirstName><LastName>Fatima</LastName></IndividualName><IndividualName><FirstName>Alastair M</FirstName><LastName>Thompson</LastName></IndividualName><IndividualName><FirstName>Alasdair</FirstName><LastName>Stenhouse</LastName></IndividualName><IndividualName><FirstName>John</FirstName><LastName>Foekens</LastName></IndividualName><IndividualName><FirstName>John</FirstName><LastName>Martens</LastName></IndividualName><IndividualName><FirstName>Anieta</FirstName><LastName>Sieuwerts</LastName></IndividualName><IndividualName><FirstName>Arjen</FirstName><LastName>Brinkman</LastName></IndividualName><IndividualName><FirstName>Henk</FirstName><LastName>Stunnenberg</LastName></IndividualName><IndividualName><FirstName>Paul N.</FirstName><LastName>Span</LastName></IndividualName><IndividualName><FirstName>Fred</FirstName><LastName>Sweep</LastName></IndividualName><IndividualName><FirstName>Christine</FirstName><LastName>Desmedt</LastName></IndividualName><IndividualName><FirstName>Christos</FirstName><LastName>Sotiriou</LastName></IndividualName><IndividualName><FirstName>Gilles</FirstName><LastName>Thomas</LastName></IndividualName><IndividualName><FirstName>Annegein</FirstName><LastName>Broeks</LastName></IndividualName><IndividualName><FirstName>Anita</FirstName><LastName>Langerod</LastName></IndividualName><IndividualName><FirstName>Samuel</FirstName><LastName>Aparicio</LastName></IndividualName><IndividualName><FirstName>Peter</FirstName><LastName>Simpson</LastName></IndividualName><IndividualName><FirstName>Laura van 't</FirstName><LastName>Veer</LastName></IndividualName><IndividualName><FirstName>Jórunn Erla</FirstName><LastName>Eyfjörd</LastName></IndividualName><IndividualName><FirstName>Holmfridur</FirstName><LastName>Hilmarsdottir</LastName></IndividualName><IndividualName><FirstName>Jon G</FirstName><LastName>Jonasson</LastName></IndividualName><IndividualName><FirstName>Anne-Lise</FirstName><LastName>Børresen-Dale</LastName></IndividualName><IndividualName><FirstName>Ming Ta</FirstName><LastName>Michael Lee</LastName></IndividualName><IndividualName><FirstName>Bernice Huimin</FirstName><LastName>Wong</LastName></IndividualName><IndividualName><FirstName>Benita Kiat</FirstName><LastName>Tee Tan</LastName></IndividualName><IndividualName><FirstName>Gerrit K.J.</FirstName><LastName>Hooijer</LastName></IndividualName></Group><Group><GroupName>ICGC Chronic Myeloid Disorders Group</GroupName><IndividualName><FirstName>Luca</FirstName><LastName>Malcovati</LastName></IndividualName><IndividualName><FirstName>Sudhir</FirstName><LastName>Tauro</LastName></IndividualName><IndividualName><FirstName>Jacqueline</FirstName><LastName>Boultwood</LastName></IndividualName><IndividualName><FirstName>Andrea</FirstName><LastName>Pellagatti</LastName></IndividualName><IndividualName><FirstName>Michael</FirstName><LastName>Groves</LastName></IndividualName><IndividualName><FirstName>Alex</FirstName><LastName>Sternberg</LastName></IndividualName><IndividualName><FirstName>Carlo</FirstName><LastName>Gambacorti-Passerini</LastName></IndividualName><IndividualName><FirstName>Paresh</FirstName><LastName>Vyas</LastName></IndividualName><IndividualName><FirstName>Eva</FirstName><LastName>Hellstrom-Lindberg</LastName></IndividualName><IndividualName><FirstName>David</FirstName><LastName>Bowen</LastName></IndividualName><IndividualName><FirstName>Nicholas CP</FirstName><LastName>Cross</LastName></IndividualName><IndividualName><FirstName>Anthony R</FirstName><LastName>Green</LastName></IndividualName><IndividualName><FirstName>Mario</FirstName><LastName>Cazzola</LastName></IndividualName></Group><Group><GroupName>ICGC Prostate Cancer Group</GroupName><IndividualName><FirstName>Colin</FirstName><LastName>Cooper</LastName></IndividualName><IndividualName><FirstName>Rosalind</FirstName><LastName>Eeles</LastName></IndividualName><IndividualName><FirstName>David</FirstName><LastName>Wedge</LastName></IndividualName><IndividualName><FirstName>Peter</FirstName><LastName>Van Loo</LastName></IndividualName><IndividualName><FirstName>Gunes</FirstName><LastName>Gundem</LastName></IndividualName><IndividualName><FirstName>Ludmil</FirstName><LastName>Alexandrov</LastName></IndividualName><IndividualName><FirstName>Barbara</FirstName><LastName>Kremeyer</LastName></IndividualName><IndividualName><FirstName>Adam</FirstName><LastName>Butler</LastName></IndividualName><IndividualName><FirstName>Andrew</FirstName><LastName>Lynch</LastName></IndividualName><IndividualName><FirstName>Sandra</FirstName><LastName>Edwards</LastName></IndividualName><IndividualName><FirstName>Niedzica</FirstName><LastName>Camacho</LastName></IndividualName><IndividualName><FirstName>Charlie</FirstName><LastName>Massie</LastName></IndividualName><IndividualName><FirstName>ZSofia</FirstName><LastName>Kote-Jarai</LastName></IndividualName><IndividualName><FirstName>Nening</FirstName><LastName>Dennis</LastName></IndividualName><IndividualName><FirstName>Sue</FirstName><LastName>Merson</LastName></IndividualName><IndividualName><FirstName>Jorge</FirstName><LastName>Zamora</LastName></IndividualName><IndividualName><FirstName>Jonathan</FirstName><LastName>Kay</LastName></IndividualName><IndividualName><FirstName>Cathy</FirstName><LastName>Corbishley</LastName></IndividualName><IndividualName><FirstName>Sarah</FirstName><LastName>Thomas</LastName></IndividualName><IndividualName><FirstName>Serena</FirstName><LastName>Nik-Zainai</LastName></IndividualName><IndividualName><FirstName>Sarah</FirstName><LastName>O'Meara</LastName></IndividualName><IndividualName><FirstName>Lucy</FirstName><LastName>Matthews</LastName></IndividualName><IndividualName><FirstName>Jeremy</FirstName><LastName>Clark</LastName></IndividualName><IndividualName><FirstName>Rachel</FirstName><LastName>Hurst</LastName></IndividualName><IndividualName><FirstName>Richard</FirstName><LastName>Mithen</LastName></IndividualName><IndividualName><FirstName>Susanna</FirstName><LastName>Cooke</LastName></IndividualName><IndividualName><FirstName>Keiran</FirstName><LastName>Raine</LastName></IndividualName><IndividualName><FirstName>David</FirstName><LastName>Jones</LastName></IndividualName><IndividualName><FirstName>Andrew</FirstName><LastName>Menzies</LastName></IndividualName><IndividualName><FirstName>Lucy</FirstName><LastName>Stebbings</LastName></IndividualName><IndividualName><FirstName>Jon</FirstName><LastName>Hinton</LastName></IndividualName><IndividualName><FirstName>Jon</FirstName><LastName>Teague</LastName></IndividualName><IndividualName><FirstName>Stuart</FirstName><LastName>McLaren</LastName></IndividualName><IndividualName><FirstName>Laura</FirstName><LastName>Mudie</LastName></IndividualName><IndividualName><FirstName>Claire</FirstName><LastName>Hardy</LastName></IndividualName><IndividualName><FirstName>Elizabeth</FirstName><LastName>Anderson</LastName></IndividualName><IndividualName><FirstName>Olivia</FirstName><LastName>Joseph</LastName></IndividualName><IndividualName><FirstName>Victoria</FirstName><LastName>Goody</LastName></IndividualName><IndividualName><FirstName>Ben</FirstName><LastName>Robinson</LastName></IndividualName><IndividualName><FirstName>Mark</FirstName><LastName>Maddison</LastName></IndividualName><IndividualName><FirstName>Stephen</FirstName><LastName>Gamble</LastName></IndividualName><IndividualName><FirstName>Christopher</FirstName><LastName>Greenman</LastName></IndividualName><IndividualName><FirstName>Dan</FirstName><LastName>Berney</LastName></IndividualName><IndividualName><FirstName>Steven</FirstName><LastName>Hazell</LastName></IndividualName><IndividualName><FirstName>Naomi</FirstName><LastName>Livni</LastName></IndividualName><IndividualName><FirstName>Cyril</FirstName><LastName>Fisher</LastName></IndividualName><IndividualName><FirstName>Christopher</FirstName><LastName>Ogden</LastName></IndividualName><IndividualName><FirstName>Pardeep</FirstName><LastName>Kumar</LastName></IndividualName><IndividualName><FirstName>Alan</FirstName><LastName>Thompson</LastName></IndividualName><IndividualName><FirstName>Christopher</FirstName><LastName>Woodhouse</LastName></IndividualName><IndividualName><FirstName>David</FirstName><LastName>Nicol</LastName></IndividualName><IndividualName><FirstName>Erik</FirstName><LastName>Mayer</LastName></IndividualName><IndividualName><FirstName>Tim</FirstName><LastName>Dudderidge</LastName></IndividualName><IndividualName><FirstName>Nimish</FirstName><LastName>Shah</LastName></IndividualName><IndividualName><FirstName>Vincent</FirstName><LastName>Gnanapragasam</LastName></IndividualName><IndividualName><FirstName>Peter</FirstName><LastName>Campbell</LastName></IndividualName><IndividualName><FirstName>Andrew</FirstName><LastName>Futreal</LastName></IndividualName><IndividualName><FirstName>Douglas</FirstName><LastName>Easton</LastName></IndividualName><IndividualName><FirstName>Anne Y</FirstName><LastName>Warren</LastName></IndividualName><IndividualName><FirstName>Christopher</FirstName><LastName>Foster</LastName></IndividualName><IndividualName><FirstName>Michael</FirstName><LastName>Stratton</LastName></IndividualName><IndividualName><FirstName>Hayley</FirstName><LastName>Whitaker</LastName></IndividualName><IndividualName><FirstName>Ultan</FirstName><LastName>McDermott</LastName></IndividualName><IndividualName><FirstName>Daniel</FirstName><LastName>Brewer</LastName></IndividualName><IndividualName><FirstName>David</FirstName><LastName>Neal</LastName></IndividualName></Group></GroupList><PublicationType>Journal Article</PublicationType><ArticleIdList><ArticleId IdType="doi">10.7554/eLife.02935</ArticleId><ArticleId IdType="pii">02935</ArticleId></ArticleIdList><History><PubDate PubStatus="received"><Year>2014</Year><Month>03</Month><Day>28</Day></PubDate><PubDate PubStatus="accepted"><Year>2014</Year><Month>09</Month><Day>26</Day></PubDate></History><Abstract><AbstractText Label="">Recent sequencing studies have extensively explored the somatic alterations present in the nuclear genomes of cancers. Although mitochondria control energy metabolism and apoptosis, the origins and impact of cancer-associated mutations in mtDNA are unclear. In this study, we analyzed somatic alterations in mtDNA from 1675 tumors. We identified 1907 somatic substitutions, which exhibited dramatic replicative strand bias, predominantly C &gt; T and A &gt; G on the mitochondrial heavy strand. This strand-asymmetric signature differs from those found in nuclear cancer genomes but matches the inferred germline process shaping primate mtDNA sequence content. A number of mtDNA mutations showed considerable heterogeneity across tumor types. Missense mutations were selectively neutral and often gradually drifted towards homoplasmy over time. In contrast, mutations resulting in protein truncation undergo negative selection and were almost exclusively heteroplasmic. Our findings indicate that the endogenous mutational mechanism has far greater impact than any other external mutagens in mitochondria and is fundamentally linked to mtDNA replication.</AbstractText></Abstract><OtherAbstract Language="eng" Type="plain-language-summary">The DNA in a cell's nucleus must be copied faithfully, and divided equally, when a cell divides to produce two new cells. Mistakes—or mutations—are sometimes made during the copying process, and mutations can also be introduced by exposing DNA to damaging agents known as mutagens, such as UV light or cigarette smoke. These mutations are then maintained in all of the descendants of the cell. Most of these mutations have no impact on the cell's characteristics (‘passenger mutations’). However, ‘driver mutations’ that allow cells to divide uncontrollably and spread to other body sites can lead to cancer. Mitochondria are cellular compartments that are responsible for generating the energy a cell needs to survive and are also responsible for initiating programmed cell death. Mitochondria contain their own DNA—entirely separate from that in the nucleus of the cell—that encodes the proteins most essential for energy production. Mitochondrial DNA molecules are frequently exposed to damaging molecules called reactive oxygen species that are produced by the mitochondria. Therefore, these reactive oxygen species have been thought to be one of the most important causes of mitochondrial DNA mutations. In addition, because cancer cells produce energy differently to normal cells, mutations in the mitochondrial DNA that change the ability of the mitochondria to produce energy have been conventionally thought to help normal cells to become cancerous. However, conclusive evidence for a link between cancer and mitochondrial DNA mutations is lacking. Ju et al. examined the mitochondrial DNA sequences taken from 1675 cancer biopsies from over thirty different types of cancer and compared these to normal tissue from the same patients. This revealed 1907 mutations in the mitochondrial DNA taken from the cancer cells. The pattern of the mutations suggests that the majority of the mutations are not introduced from reactive oxygen species, but from the errors the mitochondria themselves make in the process of duplicating their DNA when a cell divides. Unexpectedly, known mutagens, such as cigarette smoke or UV light, had a negligible effect on mitochondrial DNA mutations. Contrary to conventional wisdom, Ju et al. found no evidence that the mitochondrial DNA mutations help cancer to develop or spread. Instead, like passenger mutations found in the DNA in the cell nucleus, most mitochondrial genome mutations have no discernible effect. However, Ju et al. revealed that DNA mutations that damage normal mitochondrial activity are less likely to be maintained in cancer cells. Presumably, mitochondria containing these proteins produce less energy, and so a cell containing too many of these mutations will find it harder to survive. This shows that having enough correctly functioning mitochondria is essential for even cancer cells to thrive.</OtherAbstract><CoiStatement>YJ, LA, MG, IM, SN, MR, HD, EP, GG, AS, NB, SB, PT, JN, CM, AB, JT, GV, AG, MD, AU, JP, BT, NM, MG, PV, AE, TS, VC, RG, JT, DH, DM, CF, AW, HW, DB, RE, CC, DN, TV, WI, GB, AF, PF, AL, PC, UM, MS, PC The authors declare that no competing interests exist.</CoiStatement><ObjectList><Object Type="keyword"><Param Name="value">human</Param></Object><Object Type="keyword"><Param Name="value">genomics</Param></Object><Object Type="keyword"><Param Name="value">evolutionary biology</Param></Object><Object Type="keyword"><Param Name="value">mitochondrial DNA</Param></Object><Object Type="keyword"><Param Name="value">somatic mutation</Param></Object><Object Type="keyword"><Param Name="value">mutational signature</Param></Object><Object Type="keyword"><Param Name="value">cancer genome</Param></Object><Object Type="keyword"><Param Name="value">evolution</Param></Object><Object Type="keyword"><Param Name="value">sequencing</Param></Object><Object Type="grant"><Param Name="id">Health Innovation Challenge Fund (HICF)</Param><Param Name="grantor">Wellcome Trust</Param></Object><Object Type="grant"><Param Name="id">ALTF 1203_2012</Param><Param Name="grantor">European Molecular Biology Organization</Param></Object><Object Type="grant"><Param Name="id">Biomedical Research Center at University College London Hospitals</Param><Param Name="grantor">National Institute for Health Research</Param></Object><Object Type="grant"><Param Name="id">Breast Cancer Somatic Genetics Study (BASIS)</Param><Param Name="grantor">European Union</Param></Object><Object Type="grant"><Param Name="id">PROMPT: G0500966/75466</Param><Param Name="grantor">National Cancer Research Institute</Param></Object><Object Type="grant"><Param Name="id">Intramural Research Program of the NIH</Param><Param Name="grantor">National Institute of Environmental Health Sciences</Param></Object><Object Type="grant"><Param Name="id">Cambridge Biomedical Research Center</Param><Param Name="grantor">National Institute for Health Research</Param></Object><Object Type="grant"><Param Name="id">ALTF 1287-2012</Param><Param Name="grantor">European Molecular Biology Organization</Param></Object><Object Type="grant"><Param Name="id">Health Innovation Challenge Fund (HICF)</Param><Param Name="grantor">Department of Health</Param></Object></ObjectList></Article></ArticleSet>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE ArticleSet
+ PUBLIC "-//NLM//DTD PubMed 2.7//EN"
+  "https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd">
+<ArticleSet>
+<Article>
+<Journal>
+<PublisherName>eLife Sciences Publications, Ltd</PublisherName>
+<JournalTitle>eLife</JournalTitle>
+<Issn>2050-084X</Issn>
+<Volume>3</Volume>
+<PubDate PubStatus="epublish">
+<Year>2014</Year>
+<Month>October</Month>
+<Day>01</Day>
+</PubDate>
+</Journal>
+<Replaces IdType="doi">10.7554/eLife.02935</Replaces>
+<ArticleTitle>Origins and functional consequences of somatic mitochondrial DNA mutations in human cancer</ArticleTitle>
+<ELocationID EIdType="doi">10.7554/eLife.02935</ELocationID>
+<ELocationID EIdType="pii">e02935</ELocationID>
+<Language>EN</Language>
+<AuthorList>
+<Author>
+<FirstName>Young Seok</FirstName>
+<LastName>Ju</LastName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Ludmil B</FirstName>
+<LastName>Alexandrov</LastName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Moritz</FirstName>
+<LastName>Gerstung</LastName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Inigo</FirstName>
+<LastName>Martincorena</LastName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Serena</FirstName>
+<LastName>Nik-Zainal</LastName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Manasa</FirstName>
+<LastName>Ramakrishna</LastName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Helen R</FirstName>
+<LastName>Davies</LastName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Elli</FirstName>
+<LastName>Papaemmanuil</LastName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Gunes</FirstName>
+<LastName>Gundem</LastName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Adam</FirstName>
+<LastName>Shlien</LastName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Niccolo</FirstName>
+<LastName>Bolli</LastName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Sam</FirstName>
+<LastName>Behjati</LastName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Patrick S</FirstName>
+<LastName>Tarpey</LastName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Jyoti</FirstName>
+<LastName>Nangalia</LastName>
+<AffiliationInfo>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</Affiliation>
+</AffiliationInfo>
+</Author>
+<Author>
+<FirstName>Charles E</FirstName>
+<LastName>Massie</LastName>
+<AffiliationInfo>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</Affiliation>
+</AffiliationInfo>
+</Author>
+<Author>
+<FirstName>Adam P</FirstName>
+<LastName>Butler</LastName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Jon W</FirstName>
+<LastName>Teague</LastName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>George S</FirstName>
+<LastName>Vassiliou</LastName>
+<AffiliationInfo>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</Affiliation>
+</AffiliationInfo>
+</Author>
+<Author>
+<FirstName>Anthony R</FirstName>
+<LastName>Green</LastName>
+<AffiliationInfo>
+<Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</Affiliation>
+</AffiliationInfo>
+</Author>
+<Author>
+<FirstName>Ming-Qing</FirstName>
+<LastName>Du</LastName>
+<Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Ashwin</FirstName>
+<LastName>Unnikrishnan</LastName>
+<Affiliation>Lowy Cancer Research Centre, University of New South Wales, Sydney, Australia</Affiliation>
+</Author>
+<Author>
+<FirstName>John E</FirstName>
+<LastName>Pimanda</LastName>
+<Affiliation>Lowy Cancer Research Centre, University of New South Wales, Sydney, Australia</Affiliation>
+</Author>
+<Author>
+<FirstName>Bin Tean</FirstName>
+<LastName>Teh</LastName>
+<AffiliationInfo>
+<Affiliation>Laboratory of Cancer Epigenome, National Cancer Centre, Singapore, Singapore</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Duke-NUS Graduate Medical School, Singapore, Singapore</Affiliation>
+</AffiliationInfo>
+</Author>
+<Author>
+<FirstName>Nikhil</FirstName>
+<LastName>Munshi</LastName>
+<Affiliation>Department of Hematologic Oncology, Dana-Farber Cancer Institute, Boston, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>Mel</FirstName>
+<LastName>Greaves</LastName>
+<Affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Paresh</FirstName>
+<LastName>Vyas</LastName>
+<Affiliation>Weatherall Institute for Molecular Medicine, University of Oxford, Oxford, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Adel K</FirstName>
+<LastName>El-Naggar</LastName>
+<Affiliation>Department of Pathology, MD Anderson Cancer Center, Houston, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>Tom</FirstName>
+<LastName>Santarius</LastName>
+<Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>V Peter</FirstName>
+<LastName>Collins</LastName>
+<Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Richard</FirstName>
+<LastName>Grundy</LastName>
+<Affiliation>Children's Brain Tumour Research Centre, University of Nottingham, Nottingham, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Jack A</FirstName>
+<LastName>Taylor</LastName>
+<Affiliation>National Institute of Environmental Health Sciences, National Institute of Health, Triangle, North Carolina, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>D Neil</FirstName>
+<LastName>Hayes</LastName>
+<Affiliation>Department of Internal Medicine, University of North Carolina, Chapel Hill, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>David</FirstName>
+<LastName>Malkin</LastName>
+<Affiliation>Hospital for Sick Children, University of Toronto, Toronto, Canada</Affiliation>
+</Author>
+<Author>
+<CollectiveName>ICGC Breast Cancer Group</CollectiveName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<CollectiveName>ICGC Chronic Myeloid Disorders Group</CollectiveName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<CollectiveName>ICGC Prostate Cancer Group</CollectiveName>
+<AffiliationInfo>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Cancer Research UK Cambridge Institute, University of Cambridge, Cambridge, United Kingdom</Affiliation>
+</AffiliationInfo>
+</Author>
+<Author>
+<FirstName>Christopher S</FirstName>
+<LastName>Foster</LastName>
+<AffiliationInfo>
+<Affiliation>Department of Molecular and Clinical Cancer Medicine, University of Liverpool, London, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>HCA Pathology Laboratories, London, United Kingdom</Affiliation>
+</AffiliationInfo>
+</Author>
+<Author>
+<FirstName>Anne Y</FirstName>
+<LastName>Warren</LastName>
+<Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Hayley C</FirstName>
+<LastName>Whitaker</LastName>
+<Affiliation>Cancer Research UK Cambridge Institute, University of Cambridge, Cambridge, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Daniel</FirstName>
+<LastName>Brewer</LastName>
+<AffiliationInfo>
+<Affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>School of Biological Sciences, University of East Anglia, Norwich, United Kingdom</Affiliation>
+</AffiliationInfo>
+</Author>
+<Author>
+<FirstName>Rosalind</FirstName>
+<LastName>Eeles</LastName>
+<Affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Colin</FirstName>
+<LastName>Cooper</LastName>
+<AffiliationInfo>
+<Affiliation>Institute of Cancer Research, Sutton, London, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>School of Biological Sciences, University of East Anglia, Norwich, United Kingdom</Affiliation>
+</AffiliationInfo>
+</Author>
+<Author>
+<FirstName>David</FirstName>
+<LastName>Neal</LastName>
+<Affiliation>Cancer Research UK Cambridge Institute, University of Cambridge, Cambridge, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Tapio</FirstName>
+<LastName>Visakorpi</LastName>
+<Affiliation>Institute of Biosciences and Medical Technology - BioMediTech and Fimlab Laboratories, University of Tampere and Tampere University Hospital, Tampere, Finland</Affiliation>
+</Author>
+<Author>
+<FirstName>William B</FirstName>
+<LastName>Isaacs</LastName>
+<Affiliation>Department of Oncology, Johns Hopkins University, Baltimore, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>G Steven</FirstName>
+<LastName>Bova</LastName>
+<Affiliation>Institute of Biosciences and Medical Technology - BioMediTech and Fimlab Laboratories, University of Tampere and Tampere University Hospital, Tampere, Finland</Affiliation>
+</Author>
+<Author>
+<FirstName>Adrienne M</FirstName>
+<LastName>Flanagan</LastName>
+<AffiliationInfo>
+<Affiliation>Department of Histopathology, Royal National Orthopaedic Hospital, Middlesex, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>University College London Cancer Institute, University College London, London, United Kingdom</Affiliation>
+</AffiliationInfo>
+</Author>
+<Author>
+<FirstName>P Andrew</FirstName>
+<LastName>Futreal</LastName>
+<AffiliationInfo>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Department of Genomic Medicine, The University of Texas, MD Anderson Cancer Center, Houston, Texas, United States</Affiliation>
+</AffiliationInfo>
+</Author>
+<Author>
+<FirstName>Andy G</FirstName>
+<LastName>Lynch</LastName>
+<Affiliation>Cancer Research UK Cambridge Institute, University of Cambridge, Cambridge, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Patrick F</FirstName>
+<LastName>Chinnery</LastName>
+<Affiliation>Wellcome Trust Centre for Mitochondrial Research, Institute of Genetic Medicine, Newcastle University, Newcastle-upon-tyne, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Ultan</FirstName>
+<LastName>McDermott</LastName>
+<AffiliationInfo>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation>
+</AffiliationInfo>
+</Author>
+<Author>
+<FirstName>Michael R</FirstName>
+<LastName>Stratton</LastName>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</Author>
+<Author>
+<FirstName>Peter J</FirstName>
+<LastName>Campbell</LastName>
+<AffiliationInfo>
+<Affiliation>Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Cambridge University Hospitals NHS Foundation Trust, Cambridge, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Department of Haematology, University of Cambridge, Cambridge, United Kingdom</Affiliation>
+</AffiliationInfo>
+</Author>
+</AuthorList>
+<GroupList>
+<Group>
+<GroupName>ICGC Breast Cancer Group</GroupName>
+<IndividualName>
+<FirstName>Elena</FirstName>
+<LastName>Provenzano</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Marc</FirstName>
+<LastName>van de Vijver</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Andrea L</FirstName>
+<LastName>Richardson</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Colin</FirstName>
+<LastName>Purdie</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Sarah</FirstName>
+<LastName>Pinder</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Gaetan</FirstName>
+<LastName>MacGrogan</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Anne</FirstName>
+<LastName>Vincent-Salomon</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Denis</FirstName>
+<LastName>Larsimont</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Dorthe</FirstName>
+<LastName>Grabau</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Torill</FirstName>
+<LastName>Sauer</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Øystein</FirstName>
+<LastName>Garred</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Anna</FirstName>
+<LastName>Ehinger</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Gert G</FirstName>
+<LastName>Van den Eynden</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>C.H.M.</FirstName>
+<LastName>van Deurzen</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Roberto</FirstName>
+<LastName>Salgado</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Jane E</FirstName>
+<LastName>Brock</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Sunil R</FirstName>
+<LastName>Lakhani</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Dilip D</FirstName>
+<LastName>Giri</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Laurent</FirstName>
+<LastName>Arnould</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Jocelyne</FirstName>
+<LastName>Jacquemier</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Isabelle</FirstName>
+<LastName>Treilleux</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Carlos</FirstName>
+<LastName>Caldas</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Suet-Feung</FirstName>
+<LastName>Chin</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Aquila</FirstName>
+<LastName>Fatima</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Alastair M</FirstName>
+<LastName>Thompson</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Alasdair</FirstName>
+<LastName>Stenhouse</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>John</FirstName>
+<LastName>Foekens</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>John</FirstName>
+<LastName>Martens</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Anieta</FirstName>
+<LastName>Sieuwerts</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Arjen</FirstName>
+<LastName>Brinkman</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Henk</FirstName>
+<LastName>Stunnenberg</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Paul N.</FirstName>
+<LastName>Span</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Fred</FirstName>
+<LastName>Sweep</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Christine</FirstName>
+<LastName>Desmedt</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Christos</FirstName>
+<LastName>Sotiriou</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Gilles</FirstName>
+<LastName>Thomas</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Annegein</FirstName>
+<LastName>Broeks</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Anita</FirstName>
+<LastName>Langerod</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Samuel</FirstName>
+<LastName>Aparicio</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Peter</FirstName>
+<LastName>Simpson</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Laura van 't</FirstName>
+<LastName>Veer</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Jórunn Erla</FirstName>
+<LastName>Eyfjörd</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Holmfridur</FirstName>
+<LastName>Hilmarsdottir</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Jon G</FirstName>
+<LastName>Jonasson</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Anne-Lise</FirstName>
+<LastName>Børresen-Dale</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Ming Ta</FirstName>
+<LastName>Michael Lee</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Bernice Huimin</FirstName>
+<LastName>Wong</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Benita Kiat</FirstName>
+<LastName>Tee Tan</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Gerrit K.J.</FirstName>
+<LastName>Hooijer</LastName>
+</IndividualName>
+</Group>
+<Group>
+<GroupName>ICGC Chronic Myeloid Disorders Group</GroupName>
+<IndividualName>
+<FirstName>Luca</FirstName>
+<LastName>Malcovati</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Sudhir</FirstName>
+<LastName>Tauro</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Jacqueline</FirstName>
+<LastName>Boultwood</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Andrea</FirstName>
+<LastName>Pellagatti</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Michael</FirstName>
+<LastName>Groves</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Alex</FirstName>
+<LastName>Sternberg</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Carlo</FirstName>
+<LastName>Gambacorti-Passerini</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Paresh</FirstName>
+<LastName>Vyas</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Eva</FirstName>
+<LastName>Hellstrom-Lindberg</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>David</FirstName>
+<LastName>Bowen</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Nicholas CP</FirstName>
+<LastName>Cross</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Anthony R</FirstName>
+<LastName>Green</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Mario</FirstName>
+<LastName>Cazzola</LastName>
+</IndividualName>
+</Group>
+<Group>
+<GroupName>ICGC Prostate Cancer Group</GroupName>
+<IndividualName>
+<FirstName>Colin</FirstName>
+<LastName>Cooper</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Rosalind</FirstName>
+<LastName>Eeles</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>David</FirstName>
+<LastName>Wedge</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Peter</FirstName>
+<LastName>Van Loo</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Gunes</FirstName>
+<LastName>Gundem</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Ludmil</FirstName>
+<LastName>Alexandrov</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Barbara</FirstName>
+<LastName>Kremeyer</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Adam</FirstName>
+<LastName>Butler</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Andrew</FirstName>
+<LastName>Lynch</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Sandra</FirstName>
+<LastName>Edwards</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Niedzica</FirstName>
+<LastName>Camacho</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Charlie</FirstName>
+<LastName>Massie</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>ZSofia</FirstName>
+<LastName>Kote-Jarai</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Nening</FirstName>
+<LastName>Dennis</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Sue</FirstName>
+<LastName>Merson</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Jorge</FirstName>
+<LastName>Zamora</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Jonathan</FirstName>
+<LastName>Kay</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Cathy</FirstName>
+<LastName>Corbishley</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Sarah</FirstName>
+<LastName>Thomas</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Serena</FirstName>
+<LastName>Nik-Zainai</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Sarah</FirstName>
+<LastName>O'Meara</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Lucy</FirstName>
+<LastName>Matthews</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Jeremy</FirstName>
+<LastName>Clark</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Rachel</FirstName>
+<LastName>Hurst</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Richard</FirstName>
+<LastName>Mithen</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Susanna</FirstName>
+<LastName>Cooke</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Keiran</FirstName>
+<LastName>Raine</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>David</FirstName>
+<LastName>Jones</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Andrew</FirstName>
+<LastName>Menzies</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Lucy</FirstName>
+<LastName>Stebbings</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Jon</FirstName>
+<LastName>Hinton</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Jon</FirstName>
+<LastName>Teague</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Stuart</FirstName>
+<LastName>McLaren</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Laura</FirstName>
+<LastName>Mudie</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Claire</FirstName>
+<LastName>Hardy</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Elizabeth</FirstName>
+<LastName>Anderson</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Olivia</FirstName>
+<LastName>Joseph</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Victoria</FirstName>
+<LastName>Goody</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Ben</FirstName>
+<LastName>Robinson</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Mark</FirstName>
+<LastName>Maddison</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Stephen</FirstName>
+<LastName>Gamble</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Christopher</FirstName>
+<LastName>Greenman</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Dan</FirstName>
+<LastName>Berney</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Steven</FirstName>
+<LastName>Hazell</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Naomi</FirstName>
+<LastName>Livni</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Cyril</FirstName>
+<LastName>Fisher</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Christopher</FirstName>
+<LastName>Ogden</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Pardeep</FirstName>
+<LastName>Kumar</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Alan</FirstName>
+<LastName>Thompson</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Christopher</FirstName>
+<LastName>Woodhouse</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>David</FirstName>
+<LastName>Nicol</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Erik</FirstName>
+<LastName>Mayer</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Tim</FirstName>
+<LastName>Dudderidge</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Nimish</FirstName>
+<LastName>Shah</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Vincent</FirstName>
+<LastName>Gnanapragasam</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Peter</FirstName>
+<LastName>Campbell</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Andrew</FirstName>
+<LastName>Futreal</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Douglas</FirstName>
+<LastName>Easton</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Anne Y</FirstName>
+<LastName>Warren</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Christopher</FirstName>
+<LastName>Foster</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Michael</FirstName>
+<LastName>Stratton</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Hayley</FirstName>
+<LastName>Whitaker</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Ultan</FirstName>
+<LastName>McDermott</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>Daniel</FirstName>
+<LastName>Brewer</LastName>
+</IndividualName>
+<IndividualName>
+<FirstName>David</FirstName>
+<LastName>Neal</LastName>
+</IndividualName>
+</Group>
+</GroupList>
+<PublicationType>Journal Article</PublicationType>
+<ArticleIdList>
+<ArticleId IdType="doi">10.7554/eLife.02935</ArticleId>
+<ArticleId IdType="pii">02935</ArticleId>
+</ArticleIdList>
+<History>
+<PubDate PubStatus="received">
+<Year>2014</Year>
+<Month>03</Month>
+<Day>28</Day>
+</PubDate>
+<PubDate PubStatus="accepted">
+<Year>2014</Year>
+<Month>09</Month>
+<Day>26</Day>
+</PubDate>
+</History>
+<Abstract>
+<AbstractText Label="">Recent sequencing studies have extensively explored the somatic alterations present in the nuclear genomes of cancers. Although mitochondria control energy metabolism and apoptosis, the origins and impact of cancer-associated mutations in mtDNA are unclear. In this study, we analyzed somatic alterations in mtDNA from 1675 tumors. We identified 1907 somatic substitutions, which exhibited dramatic replicative strand bias, predominantly C &gt; T and A &gt; G on the mitochondrial heavy strand. This strand-asymmetric signature differs from those found in nuclear cancer genomes but matches the inferred germline process shaping primate mtDNA sequence content. A number of mtDNA mutations showed considerable heterogeneity across tumor types. Missense mutations were selectively neutral and often gradually drifted towards homoplasmy over time. In contrast, mutations resulting in protein truncation undergo negative selection and were almost exclusively heteroplasmic. Our findings indicate that the endogenous mutational mechanism has far greater impact than any other external mutagens in mitochondria and is fundamentally linked to mtDNA replication.</AbstractText>
+</Abstract>
+<OtherAbstract Language="eng" Type="plain-language-summary">The DNA in a cell's nucleus must be copied faithfully, and divided equally, when a cell divides to produce two new cells. Mistakes—or mutations—are sometimes made during the copying process, and mutations can also be introduced by exposing DNA to damaging agents known as mutagens, such as UV light or cigarette smoke. These mutations are then maintained in all of the descendants of the cell. Most of these mutations have no impact on the cell's characteristics (‘passenger mutations’). However, ‘driver mutations’ that allow cells to divide uncontrollably and spread to other body sites can lead to cancer. Mitochondria are cellular compartments that are responsible for generating the energy a cell needs to survive and are also responsible for initiating programmed cell death. Mitochondria contain their own DNA—entirely separate from that in the nucleus of the cell—that encodes the proteins most essential for energy production. Mitochondrial DNA molecules are frequently exposed to damaging molecules called reactive oxygen species that are produced by the mitochondria. Therefore, these reactive oxygen species have been thought to be one of the most important causes of mitochondrial DNA mutations. In addition, because cancer cells produce energy differently to normal cells, mutations in the mitochondrial DNA that change the ability of the mitochondria to produce energy have been conventionally thought to help normal cells to become cancerous. However, conclusive evidence for a link between cancer and mitochondrial DNA mutations is lacking. Ju et al. examined the mitochondrial DNA sequences taken from 1675 cancer biopsies from over thirty different types of cancer and compared these to normal tissue from the same patients. This revealed 1907 mutations in the mitochondrial DNA taken from the cancer cells. The pattern of the mutations suggests that the majority of the mutations are not introduced from reactive oxygen species, but from the errors the mitochondria themselves make in the process of duplicating their DNA when a cell divides. Unexpectedly, known mutagens, such as cigarette smoke or UV light, had a negligible effect on mitochondrial DNA mutations. Contrary to conventional wisdom, Ju et al. found no evidence that the mitochondrial DNA mutations help cancer to develop or spread. Instead, like passenger mutations found in the DNA in the cell nucleus, most mitochondrial genome mutations have no discernible effect. However, Ju et al. revealed that DNA mutations that damage normal mitochondrial activity are less likely to be maintained in cancer cells. Presumably, mitochondria containing these proteins produce less energy, and so a cell containing too many of these mutations will find it harder to survive. This shows that having enough correctly functioning mitochondria is essential for even cancer cells to thrive.</OtherAbstract>
+<CoiStatement>YJ, LA, MG, IM, SN, MR, HD, EP, GG, AS, NB, SB, PT, JN, CM, AB, JT, GV, AG, MD, AU, JP, BT, NM, MG, PV, AE, TS, VC, RG, JT, DH, DM, CF, AW, HW, DB, RE, CC, DN, TV, WI, GB, AF, PF, AL, PC, UM, MS, PC The authors declare that no competing interests exist.</CoiStatement>
+<ObjectList>
+<Object Type="keyword">
+<Param Name="value">human</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">genomics</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">evolutionary biology</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">mitochondrial DNA</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">somatic mutation</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">mutational signature</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">cancer genome</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">evolution</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">sequencing</Param>
+</Object>
+<Object Type="grant">
+<Param Name="id">Health Innovation Challenge Fund (HICF)</Param>
+<Param Name="grantor">Wellcome Trust</Param>
+</Object>
+<Object Type="grant">
+<Param Name="id">ALTF 1203_2012</Param>
+<Param Name="grantor">European Molecular Biology Organization</Param>
+</Object>
+<Object Type="grant">
+<Param Name="id">Biomedical Research Center at University College London Hospitals</Param>
+<Param Name="grantor">National Institute for Health Research</Param>
+</Object>
+<Object Type="grant">
+<Param Name="id">Breast Cancer Somatic Genetics Study (BASIS)</Param>
+<Param Name="grantor">European Union</Param>
+</Object>
+<Object Type="grant">
+<Param Name="id">PROMPT: G0500966/75466</Param>
+<Param Name="grantor">National Cancer Research Institute</Param>
+</Object>
+<Object Type="grant">
+<Param Name="id">Intramural Research Program of the NIH</Param>
+<Param Name="grantor">National Institute of Environmental Health Sciences</Param>
+</Object>
+<Object Type="grant">
+<Param Name="id">Cambridge Biomedical Research Center</Param>
+<Param Name="grantor">National Institute for Health Research</Param>
+</Object>
+<Object Type="grant">
+<Param Name="id">ALTF 1287-2012</Param>
+<Param Name="grantor">European Molecular Biology Organization</Param>
+</Object>
+<Object Type="grant">
+<Param Name="id">Health Innovation Challenge Fund (HICF)</Param>
+<Param Name="grantor">Department of Health</Param>
+</Object>
+</ObjectList>
+</Article>
+</ArticleSet>

--- a/tests/test_data/elife-pubmed-12717-20170717071707.xml
+++ b/tests/test_data/elife-pubmed-12717-20170717071707.xml
@@ -1,1 +1,126 @@
-<?xml version="1.0" encoding="utf-8"?><!DOCTYPE ArticleSet PUBLIC "-//NLM//DTD PubMed 2.7//EN"  "https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd"><ArticleSet><Article><Journal><PublisherName>eLife Sciences Publications, Ltd</PublisherName><JournalTitle>eLife</JournalTitle><Issn>2050-084X</Issn><Volume>6</Volume><PubDate PubStatus="aheadofprint"><Year>2017</Year><Month>July</Month><Day>17</Day></PubDate></Journal><ArticleTitle>Zeb1 controls neuron differentiation and germinal zone exit by a mesenchymal-epithelial-like transition</ArticleTitle><ELocationID EIdType="doi">10.7554/eLife.12717</ELocationID><ELocationID EIdType="pii">e12717</ELocationID><Language>EN</Language><AuthorList><Author><FirstName>Shalini</FirstName><LastName>Singh</LastName><Affiliation>Department of Developmental Neurobiology, St. Jude Children's Research Hospital, Memphis, United States</Affiliation></Author><Author><FirstName>Danielle</FirstName><LastName>Howell</LastName><Affiliation>Department of Developmental Neurobiology, St. Jude Children's Research Hospital, Memphis, United States</Affiliation></Author><Author><FirstName>Niraj</FirstName><LastName>Trivedi</LastName><Affiliation>Department of Developmental Neurobiology, St. Jude Children's Research Hospital, Memphis, United States</Affiliation></Author><Author><FirstName>Ketty</FirstName><LastName>Kessler</LastName><Affiliation>Universite Denis Diderot (Paris VII), Paris, France</Affiliation></Author><Author><FirstName>Taren</FirstName><LastName>Ong</LastName><Affiliation>Department of Developmental Neurobiology, St. Jude Children's Research Hospital, Memphis, United States</Affiliation></Author><Author><FirstName>Pedro</FirstName><LastName>Rosmaninho</LastName><Affiliation>Department of Molecular Neurobiology, Instituto Gulbenkian de Ciência Oeiras, Oeiras, Portugal</Affiliation></Author><Author><FirstName>Alexandre ASF</FirstName><LastName>Raposo</LastName><Affiliation>Department of Molecular Neurobiology, Instituto Gulbenkian de Ciência Oeiras, Oeiras, Portugal</Affiliation><Identifier Source="ORCID">http://orcid.org/0000-0002-2794-0508</Identifier></Author><Author><FirstName>Giles</FirstName><LastName>Robinson</LastName><Affiliation>Department of Oncology, St. Jude Children's Research Hospital, Memphis, United States</Affiliation></Author><Author><FirstName>Martine F.</FirstName><LastName>Roussel</LastName><Affiliation>Department of Tumor Cell Biology, St. Jude Children's Research Hospital, Memphis, United States</Affiliation></Author><Author><FirstName>Diogo S</FirstName><LastName>Castro</LastName><Affiliation>Department of Molecular Neurobiology, Instituto Gulbenkian de Ciência Oeiras, Oeiras, Portugal</Affiliation></Author><Author><FirstName>David J</FirstName><LastName>Solecki</LastName><Affiliation>Department of Developmental Neurobiology, St. Jude Children's Research Hospital, Memphis, United States</Affiliation><Identifier Source="ORCID">http://orcid.org/0000-0001-8481-0403</Identifier></Author></AuthorList><PublicationType>Journal Article</PublicationType><ArticleIdList><ArticleId IdType="doi">10.7554/eLife.12717</ArticleId><ArticleId IdType="pii">12717</ArticleId></ArticleIdList><History><PubDate PubStatus="received"><Year>2015</Year><Month>10</Month><Day>30</Day></PubDate><PubDate PubStatus="accepted"><Year>2016</Year><Month>05</Month><Day>03</Day></PubDate></History><Abstract><AbstractText Label="">In the developing mammalian brain, differentiating neurons mature morphologically via neuronal polarity programs. Despite discovery of polarity pathways acting concurrently with differentiation, it's unclear how neurons traverse complex polarity transitions or how neuronal progenitors delay polarization during development. We report that zinc finger and homeobox transcription factor-1 (Zeb1), a master regulator of epithelial polarity, controls neuronal differentiation by transcriptionally repressing polarity genes in neuronal progenitors. Necessity-sufficiency testing and functional target screening in cerebellar granule neuron progenitors (GNPs) reveal that Zeb1 inhibits polarization and retains progenitors in their germinal zone (GZ). Zeb1 expression is elevated in the Sonic Hedgehog (SHH) medulloblastoma subgroup originating from GNPs with persistent SHH activation. Restored polarity signaling promotes differentiation and rescues GZ exit, suggesting a model for future differentiative therapies. These results reveal unexpected parallels between neuronal differentiation and mesenchymal-to-epithelial transition and suggest that active polarity inhibition contributes to altered GZ exit in pediatric brain cancers.</AbstractText></Abstract><CopyrightInformation>© 2016, Singh et al</CopyrightInformation><CoiStatement>SS, DH, NT, KK, TO, PR, AR, GR, MR, DC, DS The authors declare that no competing interests exist.</CoiStatement><ObjectList><Object Type="keyword"><Param Name="value">mouse</Param></Object><Object Type="keyword"><Param Name="value">developmental biology</Param></Object><Object Type="keyword"><Param Name="value">stem cells</Param></Object><Object Type="keyword"><Param Name="value">neuroscience</Param></Object><Object Type="grant"><Param Name="id">1R01NS066936</Param><Param Name="grantor">National Institute of Neurological Disorders and Stroke</Param></Object><Object Type="grant"><Param Name="id">#1-FY12-455</Param><Param Name="grantor">March of Dimes Foundation</Param></Object></ObjectList></Article></ArticleSet>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE ArticleSet
+ PUBLIC "-//NLM//DTD PubMed 2.7//EN"
+  "https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd">
+<ArticleSet>
+<Article>
+<Journal>
+<PublisherName>eLife Sciences Publications, Ltd</PublisherName>
+<JournalTitle>eLife</JournalTitle>
+<Issn>2050-084X</Issn>
+<Volume>6</Volume>
+<PubDate PubStatus="aheadofprint">
+<Year>2017</Year>
+<Month>July</Month>
+<Day>17</Day>
+</PubDate>
+</Journal>
+<ArticleTitle>Zeb1 controls neuron differentiation and germinal zone exit by a mesenchymal-epithelial-like transition</ArticleTitle>
+<ELocationID EIdType="doi">10.7554/eLife.12717</ELocationID>
+<ELocationID EIdType="pii">e12717</ELocationID>
+<Language>EN</Language>
+<AuthorList>
+<Author>
+<FirstName>Shalini</FirstName>
+<LastName>Singh</LastName>
+<Affiliation>Department of Developmental Neurobiology, St. Jude Children's Research Hospital, Memphis, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>Danielle</FirstName>
+<LastName>Howell</LastName>
+<Affiliation>Department of Developmental Neurobiology, St. Jude Children's Research Hospital, Memphis, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>Niraj</FirstName>
+<LastName>Trivedi</LastName>
+<Affiliation>Department of Developmental Neurobiology, St. Jude Children's Research Hospital, Memphis, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>Ketty</FirstName>
+<LastName>Kessler</LastName>
+<Affiliation>Universite Denis Diderot (Paris VII), Paris, France</Affiliation>
+</Author>
+<Author>
+<FirstName>Taren</FirstName>
+<LastName>Ong</LastName>
+<Affiliation>Department of Developmental Neurobiology, St. Jude Children's Research Hospital, Memphis, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>Pedro</FirstName>
+<LastName>Rosmaninho</LastName>
+<Affiliation>Department of Molecular Neurobiology, Instituto Gulbenkian de Ciência Oeiras, Oeiras, Portugal</Affiliation>
+</Author>
+<Author>
+<FirstName>Alexandre ASF</FirstName>
+<LastName>Raposo</LastName>
+<Affiliation>Department of Molecular Neurobiology, Instituto Gulbenkian de Ciência Oeiras, Oeiras, Portugal</Affiliation>
+<Identifier Source="ORCID">http://orcid.org/0000-0002-2794-0508</Identifier>
+</Author>
+<Author>
+<FirstName>Giles</FirstName>
+<LastName>Robinson</LastName>
+<Affiliation>Department of Oncology, St. Jude Children's Research Hospital, Memphis, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>Martine F.</FirstName>
+<LastName>Roussel</LastName>
+<Affiliation>Department of Tumor Cell Biology, St. Jude Children's Research Hospital, Memphis, United States</Affiliation>
+</Author>
+<Author>
+<FirstName>Diogo S</FirstName>
+<LastName>Castro</LastName>
+<Affiliation>Department of Molecular Neurobiology, Instituto Gulbenkian de Ciência Oeiras, Oeiras, Portugal</Affiliation>
+</Author>
+<Author>
+<FirstName>David J</FirstName>
+<LastName>Solecki</LastName>
+<Affiliation>Department of Developmental Neurobiology, St. Jude Children's Research Hospital, Memphis, United States</Affiliation>
+<Identifier Source="ORCID">http://orcid.org/0000-0001-8481-0403</Identifier>
+</Author>
+</AuthorList>
+<PublicationType>Journal Article</PublicationType>
+<ArticleIdList>
+<ArticleId IdType="doi">10.7554/eLife.12717</ArticleId>
+<ArticleId IdType="pii">12717</ArticleId>
+</ArticleIdList>
+<History>
+<PubDate PubStatus="received">
+<Year>2015</Year>
+<Month>10</Month>
+<Day>30</Day>
+</PubDate>
+<PubDate PubStatus="accepted">
+<Year>2016</Year>
+<Month>05</Month>
+<Day>03</Day>
+</PubDate>
+</History>
+<Abstract>
+<AbstractText Label="">In the developing mammalian brain, differentiating neurons mature morphologically via neuronal polarity programs. Despite discovery of polarity pathways acting concurrently with differentiation, it's unclear how neurons traverse complex polarity transitions or how neuronal progenitors delay polarization during development. We report that zinc finger and homeobox transcription factor-1 (Zeb1), a master regulator of epithelial polarity, controls neuronal differentiation by transcriptionally repressing polarity genes in neuronal progenitors. Necessity-sufficiency testing and functional target screening in cerebellar granule neuron progenitors (GNPs) reveal that Zeb1 inhibits polarization and retains progenitors in their germinal zone (GZ). Zeb1 expression is elevated in the Sonic Hedgehog (SHH) medulloblastoma subgroup originating from GNPs with persistent SHH activation. Restored polarity signaling promotes differentiation and rescues GZ exit, suggesting a model for future differentiative therapies. These results reveal unexpected parallels between neuronal differentiation and mesenchymal-to-epithelial transition and suggest that active polarity inhibition contributes to altered GZ exit in pediatric brain cancers.</AbstractText>
+</Abstract>
+<CopyrightInformation>© 2016, Singh et al</CopyrightInformation>
+<CoiStatement>SS, DH, NT, KK, TO, PR, AR, GR, MR, DC, DS The authors declare that no competing interests exist.</CoiStatement>
+<ObjectList>
+<Object Type="keyword">
+<Param Name="value">mouse</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">developmental biology</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">stem cells</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">neuroscience</Param>
+</Object>
+<Object Type="grant">
+<Param Name="id">1R01NS066936</Param>
+<Param Name="grantor">National Institute of Neurological Disorders and Stroke</Param>
+</Object>
+<Object Type="grant">
+<Param Name="id">#1-FY12-455</Param>
+<Param Name="grantor">March of Dimes Foundation</Param>
+</Object>
+</ObjectList>
+</Article>
+</ArticleSet>

--- a/tests/test_data/elife-pubmed-15743-20170717071707.xml
+++ b/tests/test_data/elife-pubmed-15743-20170717071707.xml
@@ -1,1 +1,89 @@
-<?xml version="1.0" encoding="utf-8"?><!DOCTYPE ArticleSet PUBLIC "-//NLM//DTD PubMed 2.7//EN"  "https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd"><ArticleSet><Article><Journal><PublisherName>eLife Sciences Publications, Ltd</PublisherName><JournalTitle>eLife</JournalTitle><Issn>2050-084X</Issn><Volume>5</Volume><PubDate PubStatus="epublish"><Year>2016</Year><Month>March</Month><Day>23</Day></PubDate></Journal><ArticleTitle>Correction: Dosage compensation can buffer copy-number variation in wild yeast</ArticleTitle><ELocationID EIdType="doi">10.7554/eLife.15743</ELocationID><ELocationID EIdType="pii">e15743</ELocationID><Language>EN</Language><AuthorList><Author><FirstName>James</FirstName><LastName>Hose</LastName></Author><Author><FirstName>Chris Mun</FirstName><LastName>Yong</LastName></Author><Author><FirstName>Maria</FirstName><LastName>Sardi</LastName></Author><Author><FirstName>Zhishi</FirstName><LastName>Wang</LastName></Author><Author><FirstName>Michael A</FirstName><LastName>Newton</LastName></Author><Author><FirstName>Audrey P</FirstName><LastName>Gasch</LastName><Identifier Source="ORCID">http://orcid.org/0000-0002-8182-257X</Identifier></Author></AuthorList><PublicationType>Published Erratum</PublicationType><ArticleIdList><ArticleId IdType="doi">10.7554/eLife.15743</ArticleId><ArticleId IdType="pii">15743</ArticleId></ArticleIdList><History><PubDate PubStatus="received"><Year>2016</Year><Month>03</Month><Day>02</Day></PubDate><PubDate PubStatus="accepted"><Year>2016</Year><Month>03</Month><Day>02</Day></PubDate></History><Abstract><AbstractText Label=""/></Abstract><CopyrightInformation>© 2016, Hose et al</CopyrightInformation><ObjectList><Object Type="Erratum"><Param Name="type">doi</Param><Param Name="id">10.7554/eLife.05462</Param></Object><Object Type="keyword"><Param Name="value">computational biology</Param></Object><Object Type="keyword"><Param Name="value">systems biology</Param></Object><Object Type="keyword"><Param Name="value">genomics</Param></Object><Object Type="keyword"><Param Name="value">evolutionary biology</Param></Object></ObjectList></Article></ArticleSet>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE ArticleSet
+ PUBLIC "-//NLM//DTD PubMed 2.7//EN"
+  "https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd">
+<ArticleSet>
+<Article>
+<Journal>
+<PublisherName>eLife Sciences Publications, Ltd</PublisherName>
+<JournalTitle>eLife</JournalTitle>
+<Issn>2050-084X</Issn>
+<Volume>5</Volume>
+<PubDate PubStatus="epublish">
+<Year>2016</Year>
+<Month>March</Month>
+<Day>23</Day>
+</PubDate>
+</Journal>
+<ArticleTitle>Correction: Dosage compensation can buffer copy-number variation in wild yeast</ArticleTitle>
+<ELocationID EIdType="doi">10.7554/eLife.15743</ELocationID>
+<ELocationID EIdType="pii">e15743</ELocationID>
+<Language>EN</Language>
+<AuthorList>
+<Author>
+<FirstName>James</FirstName>
+<LastName>Hose</LastName>
+</Author>
+<Author>
+<FirstName>Chris Mun</FirstName>
+<LastName>Yong</LastName>
+</Author>
+<Author>
+<FirstName>Maria</FirstName>
+<LastName>Sardi</LastName>
+</Author>
+<Author>
+<FirstName>Zhishi</FirstName>
+<LastName>Wang</LastName>
+</Author>
+<Author>
+<FirstName>Michael A</FirstName>
+<LastName>Newton</LastName>
+</Author>
+<Author>
+<FirstName>Audrey P</FirstName>
+<LastName>Gasch</LastName>
+<Identifier Source="ORCID">http://orcid.org/0000-0002-8182-257X</Identifier>
+</Author>
+</AuthorList>
+<PublicationType>Published Erratum</PublicationType>
+<ArticleIdList>
+<ArticleId IdType="doi">10.7554/eLife.15743</ArticleId>
+<ArticleId IdType="pii">15743</ArticleId>
+</ArticleIdList>
+<History>
+<PubDate PubStatus="received">
+<Year>2016</Year>
+<Month>03</Month>
+<Day>02</Day>
+</PubDate>
+<PubDate PubStatus="accepted">
+<Year>2016</Year>
+<Month>03</Month>
+<Day>02</Day>
+</PubDate>
+</History>
+<Abstract>
+<AbstractText Label=""/>
+</Abstract>
+<CopyrightInformation>© 2016, Hose et al</CopyrightInformation>
+<ObjectList>
+<Object Type="Erratum">
+<Param Name="type">doi</Param>
+<Param Name="id">10.7554/eLife.05462</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">computational biology</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">systems biology</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">genomics</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">evolutionary biology</Param>
+</Object>
+</ObjectList>
+</Article>
+</ArticleSet>

--- a/tests/test_data/pb-pubmed-369-20170717071707.xml
+++ b/tests/test_data/pb-pubmed-369-20170717071707.xml
@@ -1,1 +1,80 @@
-<?xml version="1.0" encoding="utf-8"?><!DOCTYPE ArticleSet PUBLIC "-//NLM//DTD PubMed 2.7//EN"  "https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd"><ArticleSet><Article><Journal><PublisherName>Ubiquity Press</PublisherName><JournalTitle>Psychologica Belgica</JournalTitle><Issn>2054-670X</Issn><Volume>57</Volume><Issue>2</Issue><PubDate PubStatus="epublish"><Year>2017</Year><Month>July</Month><Day>03</Day></PubDate></Journal><ArticleTitle>Factor Structure of the Affective Style Questionnaire in Flemish Adolescents</ArticleTitle><ELocationID EIdType="doi">10.5334/pb.369</ELocationID><Language>EN</Language><AuthorList><Author><FirstName>Sara</FirstName><LastName>Erreygers</LastName><Affiliation>University of Antwerp, BE</Affiliation><Identifier Source="ORCID">http://orcid.org/0000-0002-3097-4784</Identifier></Author><Author><FirstName>Pieter</FirstName><LastName>Spooren</LastName><Affiliation>University of Antwerp, BE</Affiliation></Author></AuthorList><PublicationType>Journal Article</PublicationType><ArticleIdList><ArticleId IdType="doi">10.5334/pb.369</ArticleId></ArticleIdList><History><PubDate PubStatus="received"><Year>2016</Year><Month>10</Month><Day>07</Day></PubDate><PubDate PubStatus="accepted"><Year>2016</Year><Month>10</Month><Day>15</Day></PubDate></History><Abstract><AbstractText Label="">Emotion regulation plays an important role in both healthy and problematic adolescent psychological functioning. Emotion regulation tendencies can be assessed with the Affective Style Questionnaire (ASQ; Hofmann &amp; Kashdan, 2010), but its validity in Dutch speaking adolescents has not been investigated so far. Two methods, namely traditional confirmatory factor analysis (CFA) and the recently developed exploratory structural equations modeling (ESEM), were compared to examine the dimensional structure of the ASQ in a Flemish adolescent sample (<i>N</i> = 1,601). Although, as expected, the ESEM-model fit the data better than the CFA-model, the fit indices indicated that both models did not have an acceptable fit. With a shortened version of the ASQ, model fit improved substantially, but only the ESEM solution provided a good fit. The ESEM results support the use of the adapted ASQ to effectively assess the affective styles of concealing, adjusting and tolerating in Dutch-speaking adolescents.</AbstractText></Abstract><CopyrightInformation>Copyright: © 2017 The Author(s)</CopyrightInformation><ObjectList><Object Type="keyword"><Param Name="value">emotion regulation</Param></Object><Object Type="keyword"><Param Name="value">affective style</Param></Object><Object Type="keyword"><Param Name="value">concealing</Param></Object><Object Type="keyword"><Param Name="value">adjusting</Param></Object><Object Type="keyword"><Param Name="value">tolerating</Param></Object><Object Type="keyword"><Param Name="value">exploratory structural equations modeling</Param></Object></ObjectList></Article></ArticleSet>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE ArticleSet
+ PUBLIC "-//NLM//DTD PubMed 2.7//EN"
+  "https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd">
+<ArticleSet>
+<Article>
+<Journal>
+<PublisherName>Ubiquity Press</PublisherName>
+<JournalTitle>Psychologica Belgica</JournalTitle>
+<Issn>2054-670X</Issn>
+<Volume>57</Volume>
+<Issue>2</Issue>
+<PubDate PubStatus="epublish">
+<Year>2017</Year>
+<Month>July</Month>
+<Day>03</Day>
+</PubDate>
+</Journal>
+<ArticleTitle>Factor Structure of the Affective Style Questionnaire in Flemish Adolescents</ArticleTitle>
+<ELocationID EIdType="doi">10.5334/pb.369</ELocationID>
+<Language>EN</Language>
+<AuthorList>
+<Author>
+<FirstName>Sara</FirstName>
+<LastName>Erreygers</LastName>
+<Affiliation>University of Antwerp, BE</Affiliation>
+<Identifier Source="ORCID">http://orcid.org/0000-0002-3097-4784</Identifier>
+</Author>
+<Author>
+<FirstName>Pieter</FirstName>
+<LastName>Spooren</LastName>
+<Affiliation>University of Antwerp, BE</Affiliation>
+</Author>
+</AuthorList>
+<PublicationType>Journal Article</PublicationType>
+<ArticleIdList>
+<ArticleId IdType="doi">10.5334/pb.369</ArticleId>
+</ArticleIdList>
+<History>
+<PubDate PubStatus="received">
+<Year>2016</Year>
+<Month>10</Month>
+<Day>07</Day>
+</PubDate>
+<PubDate PubStatus="accepted">
+<Year>2016</Year>
+<Month>10</Month>
+<Day>15</Day>
+</PubDate>
+</History>
+<Abstract>
+<AbstractText Label="">
+Emotion regulation plays an important role in both healthy and problematic adolescent psychological functioning. Emotion regulation tendencies can be assessed with the Affective Style Questionnaire (ASQ; Hofmann &amp; Kashdan, 2010), but its validity in Dutch speaking adolescents has not been investigated so far. Two methods, namely traditional confirmatory factor analysis (CFA) and the recently developed exploratory structural equations modeling (ESEM), were compared to examine the dimensional structure of the ASQ in a Flemish adolescent sample (
+<i>N</i>
+ = 1,601). Although, as expected, the ESEM-model fit the data better than the CFA-model, the fit indices indicated that both models did not have an acceptable fit. With a shortened version of the ASQ, model fit improved substantially, but only the ESEM solution provided a good fit. The ESEM results support the use of the adapted ASQ to effectively assess the affective styles of concealing, adjusting and tolerating in Dutch-speaking adolescents.
+</AbstractText>
+</Abstract>
+<CopyrightInformation>Copyright: © 2017 The Author(s)</CopyrightInformation>
+<ObjectList>
+<Object Type="keyword">
+<Param Name="value">emotion regulation</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">affective style</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">concealing</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">adjusting</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">tolerating</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">exploratory structural equations modeling</Param>
+</Object>
+</ObjectList>
+</Article>
+</ArticleSet>

--- a/tests/test_data/pubmed-bmjopen-2013-003269-20170717071707.xml
+++ b/tests/test_data/pubmed-bmjopen-2013-003269-20170717071707.xml
@@ -1,1 +1,79 @@
-<?xml version="1.0" encoding="utf-8"?><!DOCTYPE ArticleSet PUBLIC "-//NLM//DTD PubMed 2.7//EN"  "https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd"><ArticleSet><Article><Journal><PublisherName>British Medical Journal Publishing Group</PublisherName><JournalTitle>BMJ Open</JournalTitle><Issn>2044-6055</Issn><Volume>4</Volume><Issue>1</Issue><PubDate PubStatus="epublish"><Year>2014</Year><Month>January</Month><Day>31</Day></PubDate></Journal><ArticleTitle>Hospital-based surveillance of rotavirus gastroenteritis among children under 5 years of age in the Republic of Ivory Coast: a cross-sectional study</ArticleTitle><ELocationID EIdType="doi">10.1136/bmjopen-2013-003269</ELocationID><ELocationID EIdType="pii">e003269</ELocationID><Language>EN</Language><AuthorList><Author><FirstName>Chantal</FirstName><LastName>Akoua-Koffi</LastName><Affiliation>1</Affiliation></Author><Author><FirstName>Vincent</FirstName><LastName>Asse Kouadio</LastName><Affiliation>2</Affiliation></Author><Author><FirstName>Jean Jacques</FirstName><LastName>Yao Atteby</LastName><Affiliation>3</Affiliation></Author></AuthorList><PublicationType>Journal Article</PublicationType><ArticleIdList><ArticleId IdType="doi">10.1136/bmjopen-2013-003269</ArticleId><ArticleId IdType="pii">bmjopen-2013-003269</ArticleId></ArticleIdList><History><PubDate PubStatus="received"><Year>2013</Year><Month>06</Month><Day>06</Day></PubDate><PubDate PubStatus="accepted"><Year>2013</Year><Month>08</Month><Day>20</Day></PubDate></History><Abstract><AbstractText Label="">To estimate the proportion of rotavirus gastroenteritis (RVGE) among children aged less than 5 years who had been diagnosed with acute gastroenteritis (AGE) and admitted to hospitals and emergency rooms (ERs). The seasonal distribution of RVGE and most prevalent rotavirus (RV) strains was also assessed.</AbstractText><AbstractText Label="">A cross-sectional hospital-based surveillance study.</AbstractText><AbstractText Label="">5 reference paediatric hospitals across Abidjan.</AbstractText><AbstractText Label="">Children aged less than 5 years, who were hospitalised/visiting ERs for WHO-defined AGE, were enrolled. Written informed consent was obtained from parents/guardians before enrolment. Children who acquired nosocomial infection were excluded from the study.</AbstractText><AbstractText Label="">The proportion of RVGE among AGE hospitalisations and ER visits was expressed with 95% exact CI. Stool samples were collected from all enrolled children and were tested for the presence of RV using an enzyme immunoassay. RV-positive samples were serotyped using reverse transcriptase-PCR.</AbstractText><AbstractText Label="">Of 357 enrolled children (mean age 13.6±11.14 months), 332 were included in the final analyses; 56.3% (187/332) were hospitalised and 43.7% (145/332) were admitted to ERs. The proportion of RVGE hospitalisations and ER visits among all AGE cases was 30.1% (95% CI 23.6% to 37.3%) and 26.9% (95% CI 19.9% to 34.9%), respectively. Ninety-five children (28.6%) were RV positive; the highest number of RVGE cases was observed in children aged 6–11 months. The number of GE cases peaked in July and August 2008; the highest percentage of RV-positive cases was observed in January 2008. G1P[8] wild-type and G8P[6] were the most commonly detected strains.</AbstractText><AbstractText Label="">RVGE causes substantial morbidity among children under 5 years of age and remains a health concern in the Republic of Ivory Coast, where implementation of prevention strategies such as vaccination might help to reduce disease burden.</AbstractText></Abstract><CopyrightInformation>Published by the BMJ Publishing Group Limited. For permission to use (where not already granted under a licence) please go to http://group.bmj.com/group/rights-licensing/permissions</CopyrightInformation><ObjectList><Object Type="keyword"><Param Name="value">epidemiology</Param></Object><Object Type="keyword"><Param Name="value">Virology</Param></Object><Object Type="keyword"><Param Name="value">Infectious Diseases</Param></Object></ObjectList></Article></ArticleSet>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE ArticleSet
+ PUBLIC "-//NLM//DTD PubMed 2.7//EN"
+  "https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd">
+<ArticleSet>
+<Article>
+<Journal>
+<PublisherName>British Medical Journal Publishing Group</PublisherName>
+<JournalTitle>BMJ Open</JournalTitle>
+<Issn>2044-6055</Issn>
+<Volume>4</Volume>
+<Issue>1</Issue>
+<PubDate PubStatus="epublish">
+<Year>2014</Year>
+<Month>January</Month>
+<Day>31</Day>
+</PubDate>
+</Journal>
+<ArticleTitle>Hospital-based surveillance of rotavirus gastroenteritis among children under 5 years of age in the Republic of Ivory Coast: a cross-sectional study</ArticleTitle>
+<ELocationID EIdType="doi">10.1136/bmjopen-2013-003269</ELocationID>
+<ELocationID EIdType="pii">e003269</ELocationID>
+<Language>EN</Language>
+<AuthorList>
+<Author>
+<FirstName>Chantal</FirstName>
+<LastName>Akoua-Koffi</LastName>
+<Affiliation>1</Affiliation>
+</Author>
+<Author>
+<FirstName>Vincent</FirstName>
+<LastName>Asse Kouadio</LastName>
+<Affiliation>2</Affiliation>
+</Author>
+<Author>
+<FirstName>Jean Jacques</FirstName>
+<LastName>Yao Atteby</LastName>
+<Affiliation>3</Affiliation>
+</Author>
+</AuthorList>
+<PublicationType>Journal Article</PublicationType>
+<ArticleIdList>
+<ArticleId IdType="doi">10.1136/bmjopen-2013-003269</ArticleId>
+<ArticleId IdType="pii">bmjopen-2013-003269</ArticleId>
+</ArticleIdList>
+<History>
+<PubDate PubStatus="received">
+<Year>2013</Year>
+<Month>06</Month>
+<Day>06</Day>
+</PubDate>
+<PubDate PubStatus="accepted">
+<Year>2013</Year>
+<Month>08</Month>
+<Day>20</Day>
+</PubDate>
+</History>
+<Abstract>
+<AbstractText Label="">To estimate the proportion of rotavirus gastroenteritis (RVGE) among children aged less than 5 years who had been diagnosed with acute gastroenteritis (AGE) and admitted to hospitals and emergency rooms (ERs). The seasonal distribution of RVGE and most prevalent rotavirus (RV) strains was also assessed.</AbstractText>
+<AbstractText Label="">A cross-sectional hospital-based surveillance study.</AbstractText>
+<AbstractText Label="">5 reference paediatric hospitals across Abidjan.</AbstractText>
+<AbstractText Label="">Children aged less than 5 years, who were hospitalised/visiting ERs for WHO-defined AGE, were enrolled. Written informed consent was obtained from parents/guardians before enrolment. Children who acquired nosocomial infection were excluded from the study.</AbstractText>
+<AbstractText Label="">The proportion of RVGE among AGE hospitalisations and ER visits was expressed with 95% exact CI. Stool samples were collected from all enrolled children and were tested for the presence of RV using an enzyme immunoassay. RV-positive samples were serotyped using reverse transcriptase-PCR.</AbstractText>
+<AbstractText Label="">Of 357 enrolled children (mean age 13.6±11.14 months), 332 were included in the final analyses; 56.3% (187/332) were hospitalised and 43.7% (145/332) were admitted to ERs. The proportion of RVGE hospitalisations and ER visits among all AGE cases was 30.1% (95% CI 23.6% to 37.3%) and 26.9% (95% CI 19.9% to 34.9%), respectively. Ninety-five children (28.6%) were RV positive; the highest number of RVGE cases was observed in children aged 6–11 months. The number of GE cases peaked in July and August 2008; the highest percentage of RV-positive cases was observed in January 2008. G1P[8] wild-type and G8P[6] were the most commonly detected strains.</AbstractText>
+<AbstractText Label="">RVGE causes substantial morbidity among children under 5 years of age and remains a health concern in the Republic of Ivory Coast, where implementation of prevention strategies such as vaccination might help to reduce disease burden.</AbstractText>
+</Abstract>
+<CopyrightInformation>Published by the BMJ Publishing Group Limited. For permission to use (where not already granted under a licence) please go to http://group.bmj.com/group/rights-licensing/permissions</CopyrightInformation>
+<ObjectList>
+<Object Type="keyword">
+<Param Name="value">epidemiology</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">Virology</Param>
+</Object>
+<Object Type="keyword">
+<Param Name="value">Infectious Diseases</Param>
+</Object>
+</ObjectList>
+</Article>
+</ArticleSet>

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -51,7 +51,7 @@ class TestGenerate(unittest.TestCase):
             articles = generate.build_articles_for_pubmed(
                 article_xmls=[file_path], config_section=config_section)
             p_xml = generate.build_pubmed_xml(articles, config_section, pub_date, False)
-            pubmed_xml = str(p_xml.output_xml())
+            pubmed_xml = str(p_xml.output_xml(pretty=True))
             model_pubmed_xml = str(
                 read_file_content(TEST_DATA_PATH + pubmed_xml_file))
             self.assertEqual(pubmed_xml, model_pubmed_xml)
@@ -99,7 +99,7 @@ class TestGenerate(unittest.TestCase):
         articles = generate.build_articles_for_pubmed(
             article_xmls=[file_path], config_section=config_section)
         # generate and write to disk
-        generate.pubmed_xml_to_disk(articles, config_section, pub_date, False)
+        generate.pubmed_xml_to_disk(articles, config_section, pub_date, False, True)
         # check the output matches
         with open(TEST_DATA_PATH + pubmed_xml_file, 'rb') as file_p:
             expected_output = file_p.read()


### PR DESCRIPTION
When enhancing support for structured abstracts, it is difficult to compare the changes in the XML test fixture files since all the XML is often on one line.

As a clean commit in this PR, convert the test fixtures to pretty XML and add an optional argument to a couple functions to generate pretty XML if desired.