### PR TITLE
Fix escaping ampersand in plain text summary.

### DIFF
--- a/elifepubmed/generate.py
+++ b/elifepubmed/generate.py
@@ -420,6 +420,7 @@ def set_plain_language_summary(parent, article):
         # tweak to add spaces between paragraph tags
         tag_converted_digest = tag_converted_digest.replace('</p><p>', '</p> <p>')
         tag_converted_digest = eautils.remove_tag('p', tag_converted_digest)
+        tag_converted_digest = etoolsutils.escape_ampersand(tag_converted_digest)
         tag_converted_digest = etoolsutils.escape_unmatched_angle_brackets(
             tag_converted_digest, utils.allowed_tags())
         minidom_tag = xmlio.reparsed_tag(

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -241,6 +241,19 @@ class TestPlainLanguageSummary(unittest.TestCase):
         generate.set_plain_language_summary(parent_tag, article)
         self.assertEqual(ElementTree.tostring(parent_tag), expected)
 
+    def test_set_plain_language_summary_edge_case(self):
+        "test escaping ampersand character"
+        digest = '<p>CUT&Tag.</p>'
+        expected = (
+            b'<root><OtherAbstract Language="eng" Type="plain-language-summary">'
+            b'CUT&amp;Tag.</OtherAbstract></root>'
+        )
+        article = Article()
+        article.digest = digest
+        parent_tag = Element('root')
+        generate.set_plain_language_summary(parent_tag, article)
+        self.assertEqual(ElementTree.tostring(parent_tag), expected)
+
 
 class TestSetDatasets(unittest.TestCase):
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6404

There was an eLife article stuck in the outbox and not sent, and it is because of an `&` in the digest content failing to be converted to the plain text summary due to not well-formed XML output.

This code will escape the ampersand character, and a test scenario is included for coverage.