### PR TITLE
Bug fix removing multiple Group tags.

### DIFF
--- a/elifepubmed/generate.py
+++ b/elifepubmed/generate.py
@@ -202,10 +202,15 @@ class PubMedXML(object):
             set_group_individual(matched_group, contributor)
 
         # Remove any GroupName with no IndividualName
+        group_delete_indexes = []
         if self.groups and len(self.groups) > 0:
             for i, tag in enumerate(self.groups):
                 if len(tag.findall('.//IndividualName')) <= 0:
-                    del self.groups[i]
+                    # mark the group for deletion
+                    group_delete_indexes.append(i)
+        # delete groups by index in reverse order to avoid index reordering side effect
+        for i in sorted(group_delete_indexes)[::-1]:
+            del self.groups[i]
 
         # Remove a completely empty GroupList element, if empty
         if len(self.groups) <= 0:

--- a/tests/test_generate_edge_cases.py
+++ b/tests/test_generate_edge_cases.py
@@ -272,6 +272,16 @@ class TestSetGroupList(unittest.TestCase):
         )
         contributor1.group_author_key = group_author_name
         article.add_contributor(contributor1)
+        # add another group with no individuals
+        group_author_name = "Test Group Two"
+        contributor2 = Contributor(
+            contrib_type="author",
+            surname=None,
+            given_name=None,
+            collab=group_author_name,
+        )
+        contributor2.group_author_key = group_author_name
+        article.add_contributor(contributor2)
         # generate the PubMed XML
         p_xml = generate.build_pubmed_xml([article])
         pubmed_xml_string = p_xml.output_xml()


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6500

eLife article `58430` has more than one `<collab>` author, resulting in more than one PubMed XML deposit `<Group>` tag which has no individuals. There is a bug with the logic because it modifies the list by deleting unwanted tags in each iteration, and it misses removing the second unwanted `<Group>` tag.

The fix here first collects the indexes of group tags to remove, and then in a separate loop, it removes them by index in reverse order, resulting in all the particular group tags are removed, and it doesn't cause any `index out of range` exceptions.