### PR TITLE
Refactor affiliations, add to IndividualName tags.

### DIFF
--- a/elifepubmed/generate.py
+++ b/elifepubmed/generate.py
@@ -264,6 +264,22 @@ def set_group_individual(parent, contributor):
     else:
         set_first_name(individual, contributor)
         set_surname(individual, contributor)
+    set_affiliation(individual, contributor)
+
+
+def set_affiliation(parent, contributor):
+    # Add each affiliation for multiple affiliation support
+    non_blank_aff_count = len([aff for aff in contributor.affiliations if aff.text != ""])
+    for aff in contributor.affiliations:
+        if aff.text != "":
+            if non_blank_aff_count == 1:
+                affiliation = SubElement(parent, "Affiliation")
+                affiliation.text = aff.text
+            elif non_blank_aff_count > 1:
+                # Wrap each in AffiliationInfo tag
+                affiliation_info = SubElement(parent, "AffiliationInfo")
+                affiliation = SubElement(affiliation_info, "Affiliation")
+                affiliation.text = aff.text
 
 
 def group_exists(group_tags, group_name_text):
@@ -339,17 +355,7 @@ def set_contributor(parent, contributor, contrib_type):
         suffix.text = contributor.suffix
 
     # Add each affiliation for multiple affiliation support
-    non_blank_aff_count = len([aff for aff in contributor.affiliations if aff.text != ""])
-    for aff in contributor.affiliations:
-        if aff.text != "":
-            if non_blank_aff_count == 1:
-                affiliation = SubElement(person_name, "Affiliation")
-                affiliation.text = aff.text
-            elif non_blank_aff_count > 1:
-                # Wrap each in AffiliationInfo tag
-                affiliation_info = SubElement(person_name, "AffiliationInfo")
-                affiliation = SubElement(affiliation_info, "Affiliation")
-                affiliation.text = aff.text
+    set_affiliation(person_name, contributor)
 
     if contributor.orcid:
         orcid = SubElement(person_name, "Identifier")

--- a/tests/test_data/elife-pubmed-00666-20170717071707.xml
+++ b/tests/test_data/elife-pubmed-00666-20170717071707.xml
@@ -47,26 +47,37 @@
 <IndividualName>
 <FirstName>Alistair</FirstName>
 <LastName>Shearer</LastName>
+<Affiliation>eLife, Cambridge, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Hannah</FirstName>
 <LastName>Caton</LastName>
+<AffiliationInfo>
+<Affiliation>eLife, Cambridge, United Kingdom</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>eLife Institute, Cambridge, United Kingdom</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>Wei Mun</FirstName>
 <LastName>Chan</LastName>
+<Affiliation>eLife, Cambridge, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Hannah</FirstName>
 <LastName>Drury</LastName>
+<Affiliation>eLife, Cambridge, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Maria</FirstName>
 <LastName>Guerreiro</LastName>
+<Affiliation>eLife, Cambridge, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Susanna</FirstName>
 <LastName>Richmond</LastName>
+<Affiliation>eLife, Cambridge, United Kingdom</Affiliation>
 </IndividualName>
 </Group>
 <Group>
@@ -74,14 +85,17 @@
 <IndividualName>
 <FirstName>Graham</FirstName>
 <LastName>Nott</LastName>
+<Affiliation>Graham Nott Enterprises, Victoria, Canada</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Chris</FirstName>
 <LastName>Wilkinson</LastName>
+<Affiliation>eLife, Cambridge, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Luke</FirstName>
 <LastName>Skibinski</LastName>
+<Affiliation>eLife, Cambridge, United Kingdom</Affiliation>
 </IndividualName>
 </Group>
 <Group>

--- a/tests/test_data/elife-pubmed-02935-20170717071707.xml
+++ b/tests/test_data/elife-pubmed-02935-20170717071707.xml
@@ -370,198 +370,285 @@
 <IndividualName>
 <FirstName>Elena</FirstName>
 <LastName>Provenzano</LastName>
+<Affiliation>Cambridge Breast Unit, Addenbrooke’s Hospital, Cambridge University Hospital NHS Foundation Trust and NIHR Cambridge Biomedical Research Centre, Cambridge CB2 2QQ, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Marc</FirstName>
 <LastName>van de Vijver</LastName>
+<Affiliation>Department of Pathology, Academic Medical Center, Meibergdreef 9, 1105 AZ Amsterdam, The Netherlands</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Andrea L</FirstName>
 <LastName>Richardson</LastName>
+<AffiliationInfo>
+<Affiliation>Department of Cancer Biology, Dana-Farber Cancer Institute, 450 Brookline Ave., Boston, Massachusetts 02215, USA</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Department of Pathology, Brigham and Women's Hospital, Harvard Medical School, 75 Francis St., Boston, Massachusetts 02115, USA</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>Colin</FirstName>
 <LastName>Purdie</LastName>
+<Affiliation>East of Scotland Breast Service, Ninewells Hospital, Dundee, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Sarah</FirstName>
 <LastName>Pinder</LastName>
+<Affiliation>Department of Research Oncology, Guy’s Hospital, King’s Health Partners AHSC, King’s College London School of Medicine, London SE1 9RT, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Gaetan</FirstName>
 <LastName>MacGrogan</LastName>
+<Affiliation>Institut Bergonié, 229 cours de l’Argone, 33076, Bordeaux, France</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Anne</FirstName>
 <LastName>Vincent-Salomon</LastName>
+<AffiliationInfo>
+<Affiliation>Institut Curie, Department of Tumor Biology, 26 rue d’Ulm, 75248 Paris cédex 05, France</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Institut Curie, INSERM Unit 830, 26 rue d’Ulm, 75248 Paris cédex 05, France</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>Denis</FirstName>
 <LastName>Larsimont</LastName>
+<Affiliation>Department of Pathology, Jules Bordet Institute, Brussels 1000, Belgium</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Dorthe</FirstName>
 <LastName>Grabau</LastName>
+<Affiliation>Department of Pathology, Skåne University Hospital, Lund University, SE-221 85 Lund, Sweden</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Torill</FirstName>
 <LastName>Sauer</LastName>
+<Affiliation>Department of Pathology, Oslo University Hospital Ulleval and University of Oslo, Faculty of Medicine and Institute of Clinical Medicine, Oslo, Norway</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Øystein</FirstName>
 <LastName>Garred</LastName>
+<Affiliation>Department of Pathology, Oslo University Hospital Ulleval and University of Oslo, Faculty of Medicine and Institute of Clinical Medicine, Oslo, Norway</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Anna</FirstName>
 <LastName>Ehinger</LastName>
+<Affiliation>Department of Gynecology &amp; Obstetrics, Department of Clinical Sciences, Lund University, Skåne University Hospital Lund, SE-221 85 Lund, Sweden</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Gert G</FirstName>
 <LastName>Van den Eynden</LastName>
+<Affiliation>Translational Cancer Research Unit, GZA Hospitals St.-Augustinus, Antwerp, Belgium</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>C.H.M.</FirstName>
 <LastName>van Deurzen</LastName>
+<Affiliation>Department of Pathology, Erasmus Medical Center, Rotterdam, the Netherlands</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Roberto</FirstName>
 <LastName>Salgado</LastName>
+<Affiliation>Breast Cancer Translational Research Laboratory, Institut Jules Bordet, Université Libre de Bruxelles, Brussels, Belgium</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Jane E</FirstName>
 <LastName>Brock</LastName>
+<Affiliation>Department of Pathology, Brigham and Women's Hospital, Harvard Medical School, 75 Francis St., Boston, Massachusetts 02115, USA</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Sunil R</FirstName>
 <LastName>Lakhani</LastName>
+<AffiliationInfo>
+<Affiliation>The University of Queensland, School of Medicine, Herston, Brisbane, QLD 4006, Australia</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Pathology Queensland: The Royal Brisbane &amp; Women’s Hospital, Brisbane, QLD 4029, Australia</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>The University of Queensland, UQ Centre for Clinical Research, Herston, Brisbane, QLD 4029, Australia</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>Dilip D</FirstName>
 <LastName>Giri</LastName>
+<Affiliation>Department of Pathology, Memorial Sloan-Kettering Cancer Center, New York, USA</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Laurent</FirstName>
 <LastName>Arnould</LastName>
+<Affiliation>Centre Georges-François Leclerc, Dijon, France</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Jocelyne</FirstName>
 <LastName>Jacquemier</LastName>
+<Affiliation>biopathology department, 0nstitut Paoli Calmettes, Marseille, France</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Isabelle</FirstName>
 <LastName>Treilleux</LastName>
+<Affiliation>Centre Léon Bérard, Lyon, France</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Carlos</FirstName>
 <LastName>Caldas</LastName>
+<AffiliationInfo>
+<Affiliation>Cambridge Breast Unit, Addenbrooke’s Hospital, Cambridge University Hospital NHS Foundation Trust and NIHR Cambridge Biomedical Research Centre, Cambridge, UK</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Department of Oncology, University of Cambridge and Cancer Research UK Cambridge Research Institute, Li Ka Shin Centre, Cambridge</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>Suet-Feung</FirstName>
 <LastName>Chin</LastName>
+<Affiliation>Department of Oncology, University of Cambridge and Cancer Research UK Cambridge Research Institute, Li Ka Shin Centre, Cambridge</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Aquila</FirstName>
 <LastName>Fatima</LastName>
+<Affiliation>Department of Cancer Biology, Dana-Farber Cancer Institute, Massachusetts, USA</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Alastair M</FirstName>
 <LastName>Thompson</LastName>
+<Affiliation>Dundee Cancer Centre, Ninewells Hospital, Dundee, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Alasdair</FirstName>
 <LastName>Stenhouse</LastName>
+<Affiliation>Dundee Cancer Centre, Ninewells Hospital, Dundee, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>John</FirstName>
 <LastName>Foekens</LastName>
+<Affiliation>Erasmus MC Cancer Institute, Erasmus University Medical Center, Rotterdam, The Netherlands</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>John</FirstName>
 <LastName>Martens</LastName>
+<Affiliation>Erasmus MC Cancer Institute, Erasmus University Medical Center, Rotterdam, The Netherlands</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Anieta</FirstName>
 <LastName>Sieuwerts</LastName>
+<Affiliation>Erasmus MC Cancer Institute, Erasmus University Medical Center, Rotterdam, The Netherlands</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Arjen</FirstName>
 <LastName>Brinkman</LastName>
+<Affiliation>Department of Molecular Biology, Faculty of Science, Nijmegen Centre for Molecular Life Sciences, Radboud University, Nijmegen, The Netherlands</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Henk</FirstName>
 <LastName>Stunnenberg</LastName>
+<Affiliation>Department of Molecular Biology, Faculty of Science, Nijmegen Centre for Molecular Life Sciences, Radboud University, Nijmegen, The Netherlands</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Paul N.</FirstName>
 <LastName>Span</LastName>
+<Affiliation>Department of Radiation Oncology, Radboud University Medical Centre, Nijmegen, The Netherlands</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Fred</FirstName>
 <LastName>Sweep</LastName>
+<Affiliation>Department of Laboratory Medicine, Radboud University Medical Centre, Nijmegen, The Netherlands</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Christine</FirstName>
 <LastName>Desmedt</LastName>
+<Affiliation>Breast Cancer Translational Research Laboratory, Institut Jules Bordet, Université Libre de Bruxelles, Brussels, Belgium</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Christos</FirstName>
 <LastName>Sotiriou</LastName>
+<Affiliation>Breast Cancer Translational Research Laboratory, Institut Jules Bordet, Université Libre de Bruxelles, Brussels, Belgium</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Gilles</FirstName>
 <LastName>Thomas</LastName>
+<Affiliation>Universite Lyon1, INCa-Synergie, Centre Leon Berard, Lyon Cedex 08, France</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Annegein</FirstName>
 <LastName>Broeks</LastName>
+<Affiliation>Department Experimental Therapy, The Netherlands Cancer Institute, Amsterdam, The Netherlands</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Anita</FirstName>
 <LastName>Langerod</LastName>
+<Affiliation>Department of Genetics, Institute for Cancer Research, The Norwegian Radium Hospital, Oslo University Hospital, Oslo, Norway</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Samuel</FirstName>
 <LastName>Aparicio</LastName>
+<Affiliation>Department of Molecular Oncology, BC Cancer Agency, Vancouver</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Peter</FirstName>
 <LastName>Simpson</LastName>
+<Affiliation>The University of Queensland, UQ Centre for Clinical Research, Herston, Brisbane, Australia</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Laura van 't</FirstName>
 <LastName>Veer</LastName>
+<AffiliationInfo>
+<Affiliation>Division of Molecular Carcinogenesis, The Netherlands Cancer Institute, Amsterdam, The Netherlands</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Department of Surgery, University of California, San Francisco, San Francisco, California, United States of America</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>Jórunn Erla</FirstName>
 <LastName>Eyfjörd</LastName>
+<Affiliation>Cancer Research Laboratory, Faculty of Medicine, University of Iceland, Reykjavik, Iceland</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Holmfridur</FirstName>
 <LastName>Hilmarsdottir</LastName>
+<Affiliation>Cancer Research Laboratory, Faculty of Medicine, University of Iceland, Reykjavik, Iceland</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Jon G</FirstName>
 <LastName>Jonasson</LastName>
+<AffiliationInfo>
+<Affiliation>Department of Pathology, University Hospital, Reykjavik, Iceland</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Icelandic Cancer Registry, Icelandic Cancer Society, Reykjavik, Iceland</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>Anne-Lise</FirstName>
 <LastName>Børresen-Dale</LastName>
+<AffiliationInfo>
+<Affiliation>Department of Genetics, Institute for Cancer Research, The Norwegian Radium Hospital, Oslo University Hospital, Oslo, Norway</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Institute for Clinical Medicine, Faculty of Medicine, University of Oslo</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>Ming Ta</FirstName>
 <LastName>Michael Lee</LastName>
+<Affiliation>National Genotyping Center, Institute of Biomedical Sciences, Nankang, ROC</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Bernice Huimin</FirstName>
 <LastName>Wong</LastName>
+<Affiliation>NCCS-VARI Translational Research Laboratory, National Cancer Centre Singapore, Singapore</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Benita Kiat</FirstName>
 <LastName>Tee Tan</LastName>
+<Affiliation>Department of General Surgery, Singapore General Hospital, Singapore</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Gerrit K.J.</FirstName>
 <LastName>Hooijer</LastName>
+<Affiliation>Department of Pathology, Academic Medical Center, Amsterdam, The Netherlands</Affiliation>
 </IndividualName>
 </Group>
 <Group>
@@ -569,54 +656,72 @@
 <IndividualName>
 <FirstName>Luca</FirstName>
 <LastName>Malcovati</LastName>
+<Affiliation>Fondazione IRCCS Policlinico San Matteo, University of Pavia, Pavia, Italy</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Sudhir</FirstName>
 <LastName>Tauro</LastName>
+<Affiliation>Division of Medial Sciences, University of Dundee, Dundee, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Jacqueline</FirstName>
 <LastName>Boultwood</LastName>
+<Affiliation>Nuffield Department of Clinical Laboratory Sciences, University of Oxford, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Andrea</FirstName>
 <LastName>Pellagatti</LastName>
+<Affiliation>Nuffield Department of Clinical Laboratory Sciences, University of Oxford, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Michael</FirstName>
 <LastName>Groves</LastName>
+<Affiliation>Division of Medial Sciences, University of Dundee, Dundee, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Alex</FirstName>
 <LastName>Sternberg</LastName>
+<AffiliationInfo>
+<Affiliation>Weatherall Institute of Molecular Medicine, University of Oxford, UK</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Department of Haematology, Great Western Hospital, Swindon, UK</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>Carlo</FirstName>
 <LastName>Gambacorti-Passerini</LastName>
+<Affiliation>Department of Haematology, University of Milan Bicocca, Milan, Italy</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Paresh</FirstName>
 <LastName>Vyas</LastName>
+<Affiliation>Weatherall Institute of Molecular Medicine, University of Oxford, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Eva</FirstName>
 <LastName>Hellstrom-Lindberg</LastName>
+<Affiliation>Department of Haematology, Karolinska Institute, Stockholm, Sweden</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>David</FirstName>
 <LastName>Bowen</LastName>
+<Affiliation>St James Institute of Oncology, St James Hospital, Leeds, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Nicholas CP</FirstName>
 <LastName>Cross</LastName>
+<Affiliation>School of Medicine, University of Southampton, Southampton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Anthony R</FirstName>
 <LastName>Green</LastName>
+<Affiliation>Department of Haematology, University of Cambridge, Cambridge, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Mario</FirstName>
 <LastName>Cazzola</LastName>
+<Affiliation>Fondazione IRCCS Policlinico San Matteo, University of Pavia, Pavia, Italy</Affiliation>
 </IndividualName>
 </Group>
 <Group>
@@ -624,262 +729,386 @@
 <IndividualName>
 <FirstName>Colin</FirstName>
 <LastName>Cooper</LastName>
+<AffiliationInfo>
+<Affiliation>Division of Genetics and Epidemiology, The Institute Of Cancer Research, Sutton, UK</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Department of Biological Sciences and School of Medicine, University of East Anglia, Norwich, UK</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Senior Principal Investigators of the Cancer Research UK funded ICGC Prostate Cancer Project</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>Rosalind</FirstName>
 <LastName>Eeles</LastName>
+<AffiliationInfo>
+<Affiliation>Division of Genetics and Epidemiology, The Institute Of Cancer Research, Sutton, UK</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Royal Marsden NHS Foundation Trust, London and Sutton, UK</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Senior Principal Investigators of the Cancer Research UK funded ICGC Prostate Cancer Project</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>David</FirstName>
 <LastName>Wedge</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Peter</FirstName>
 <LastName>Van Loo</LastName>
+<AffiliationInfo>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Human Genome Laboratory, Department of Human Genetics, VIB and KU Leuven, Leuven, Belgium</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>Gunes</FirstName>
 <LastName>Gundem</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Ludmil</FirstName>
 <LastName>Alexandrov</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Barbara</FirstName>
 <LastName>Kremeyer</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Adam</FirstName>
 <LastName>Butler</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Andrew</FirstName>
 <LastName>Lynch</LastName>
+<Affiliation>Statistics and Computational Biology Laboratory, Cancer Research UK Cambridge Research Institute, Cambridge, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Sandra</FirstName>
 <LastName>Edwards</LastName>
+<Affiliation>Division of Genetics and Epidemiology, The Institute Of Cancer Research, Sutton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Niedzica</FirstName>
 <LastName>Camacho</LastName>
+<Affiliation>Division of Genetics and Epidemiology, The Institute Of Cancer Research, Sutton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Charlie</FirstName>
 <LastName>Massie</LastName>
+<Affiliation>Urological Research Laboratory, Cancer Research UK Cambridge Research Institute, Cambridge, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>ZSofia</FirstName>
 <LastName>Kote-Jarai</LastName>
+<Affiliation>Division of Genetics and Epidemiology, The Institute Of Cancer Research, Sutton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Nening</FirstName>
 <LastName>Dennis</LastName>
+<Affiliation>Royal Marsden NHS Foundation Trust, London and Sutton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Sue</FirstName>
 <LastName>Merson</LastName>
+<Affiliation>Division of Genetics and Epidemiology, The Institute Of Cancer Research, Sutton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Jorge</FirstName>
 <LastName>Zamora</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Jonathan</FirstName>
 <LastName>Kay</LastName>
+<Affiliation>Urological Research Laboratory, Cancer Research UK Cambridge Research Institute, Cambridge, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Cathy</FirstName>
 <LastName>Corbishley</LastName>
+<Affiliation>Department of Histopathology, St Georges Hospital, London, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Sarah</FirstName>
 <LastName>Thomas</LastName>
+<Affiliation>Royal Marsden NHS Foundation Trust, London and Sutton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Serena</FirstName>
 <LastName>Nik-Zainai</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Sarah</FirstName>
 <LastName>O'Meara</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Lucy</FirstName>
 <LastName>Matthews</LastName>
+<Affiliation>Division of Genetics and Epidemiology, The Institute Of Cancer Research, Sutton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Jeremy</FirstName>
 <LastName>Clark</LastName>
+<Affiliation>Department of Biological Sciences and School of Medicine, University of East Anglia, Norwich, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Rachel</FirstName>
 <LastName>Hurst</LastName>
+<Affiliation>Department of Biological Sciences and School of Medicine, University of East Anglia, Norwich, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Richard</FirstName>
 <LastName>Mithen</LastName>
+<Affiliation>Institute of Food Research, Norwich Research Park, Norwich, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Susanna</FirstName>
 <LastName>Cooke</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Keiran</FirstName>
 <LastName>Raine</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>David</FirstName>
 <LastName>Jones</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Andrew</FirstName>
 <LastName>Menzies</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Lucy</FirstName>
 <LastName>Stebbings</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Jon</FirstName>
 <LastName>Hinton</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Jon</FirstName>
 <LastName>Teague</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Stuart</FirstName>
 <LastName>McLaren</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Laura</FirstName>
 <LastName>Mudie</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Claire</FirstName>
 <LastName>Hardy</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Elizabeth</FirstName>
 <LastName>Anderson</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Olivia</FirstName>
 <LastName>Joseph</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Victoria</FirstName>
 <LastName>Goody</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Ben</FirstName>
 <LastName>Robinson</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Mark</FirstName>
 <LastName>Maddison</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Stephen</FirstName>
 <LastName>Gamble</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Christopher</FirstName>
 <LastName>Greenman</LastName>
+<Affiliation>School of Computing Sciences, University of East Anglia, Norwich, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Dan</FirstName>
 <LastName>Berney</LastName>
+<Affiliation>Department of Molecular Oncology, Barts Cancer Centre, Barts and the London School of Medicine and Dentistry, London, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Steven</FirstName>
 <LastName>Hazell</LastName>
+<Affiliation>Royal Marsden NHS Foundation Trust, London and Sutton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Naomi</FirstName>
 <LastName>Livni</LastName>
+<Affiliation>Royal Marsden NHS Foundation Trust, London and Sutton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Cyril</FirstName>
 <LastName>Fisher</LastName>
+<Affiliation>Royal Marsden NHS Foundation Trust, London and Sutton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Christopher</FirstName>
 <LastName>Ogden</LastName>
+<Affiliation>Royal Marsden NHS Foundation Trust, London and Sutton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Pardeep</FirstName>
 <LastName>Kumar</LastName>
+<Affiliation>Royal Marsden NHS Foundation Trust, London and Sutton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Alan</FirstName>
 <LastName>Thompson</LastName>
+<Affiliation>Royal Marsden NHS Foundation Trust, London and Sutton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Christopher</FirstName>
 <LastName>Woodhouse</LastName>
+<Affiliation>Royal Marsden NHS Foundation Trust, London and Sutton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>David</FirstName>
 <LastName>Nicol</LastName>
+<Affiliation>Royal Marsden NHS Foundation Trust, London and Sutton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Erik</FirstName>
 <LastName>Mayer</LastName>
+<Affiliation>Royal Marsden NHS Foundation Trust, London and Sutton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Tim</FirstName>
 <LastName>Dudderidge</LastName>
+<Affiliation>Royal Marsden NHS Foundation Trust, London and Sutton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Nimish</FirstName>
 <LastName>Shah</LastName>
+<Affiliation>Urological Research Laboratory, Cancer Research UK Cambridge Research Institute, Cambridge, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Vincent</FirstName>
 <LastName>Gnanapragasam</LastName>
+<Affiliation>Urological Research Laboratory, Cancer Research UK Cambridge Research Institute, Cambridge, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Peter</FirstName>
 <LastName>Campbell</LastName>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Andrew</FirstName>
 <LastName>Futreal</LastName>
+<AffiliationInfo>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Senior Principal Investigators of the Cancer Research UK funded ICGC Prostate Cancer Project</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>Douglas</FirstName>
 <LastName>Easton</LastName>
+<AffiliationInfo>
+<Affiliation>Centre for Cancer Genetic Epidemiology, Department of Oncology, University of Cambridge, Cambridge, UK</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Senior Principal Investigators of the Cancer Research UK funded ICGC Prostate Cancer Project</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>Anne Y</FirstName>
 <LastName>Warren</LastName>
+<Affiliation>Department of Histopathology, Cambridge University Hospitals NHS Foundation Trust, Cambridge, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Christopher</FirstName>
 <LastName>Foster</LastName>
+<AffiliationInfo>
+<Affiliation>Bostwick Laboratories, London, UK</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Senior Principal Investigators of the Cancer Research UK funded ICGC Prostate Cancer Project</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>Michael</FirstName>
 <LastName>Stratton</LastName>
+<AffiliationInfo>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Senior Principal Investigators of the Cancer Research UK funded ICGC Prostate Cancer Project</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>Hayley</FirstName>
 <LastName>Whitaker</LastName>
+<Affiliation>Urological Research Laboratory, Cancer Research UK Cambridge Research Institute, Cambridge, UK</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Ultan</FirstName>
 <LastName>McDermott</LastName>
+<AffiliationInfo>
+<Affiliation>Cancer Genome Project,, Wellcome Trust Sanger Institute, Hinxton, UK</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Senior Principal Investigators of the Cancer Research UK funded ICGC Prostate Cancer Project</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>Daniel</FirstName>
 <LastName>Brewer</LastName>
+<AffiliationInfo>
+<Affiliation>Division of Genetics and Epidemiology, The Institute Of Cancer Research, Sutton, UK</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Department of Biological Sciences and School of Medicine, University of East Anglia, Norwich, UK</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 <IndividualName>
 <FirstName>David</FirstName>
 <LastName>Neal</LastName>
+<AffiliationInfo>
+<Affiliation>Urological Research Laboratory, Cancer Research UK Cambridge Research Institute, Cambridge, UK</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Department of Surgical Oncology, University of Cambridge, Addenbrooke's Hospital, Cambridge, UK</Affiliation>
+</AffiliationInfo>
+<AffiliationInfo>
+<Affiliation>Senior Principal Investigators of the Cancer Research UK funded ICGC Prostate Cancer Project</Affiliation>
+</AffiliationInfo>
 </IndividualName>
 </Group>
 </GroupList>

--- a/tests/test_data/elife-pubmed-60675-20170717071707.xml
+++ b/tests/test_data/elife-pubmed-60675-20170717071707.xml
@@ -418,434 +418,542 @@
 <IndividualName>
 <FirstName>Adam JR</FirstName>
 <LastName>Watson</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Adan</FirstName>
 <LastName>Taylor</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Alan</FirstName>
 <LastName>Chetwynd</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Alexander</FirstName>
 <LastName>Grassam-Rowe</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Alexandra S</FirstName>
 <LastName>Mighiu</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Angus</FirstName>
 <LastName>Livingstone</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Annabel</FirstName>
 <LastName>Killen</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Caitlin</FirstName>
 <LastName>Rigler</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Callum</FirstName>
 <LastName>Harries</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Cameron</FirstName>
 <LastName>East</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Charlotte</FirstName>
 <LastName>Lee</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Chris JB</FirstName>
 <LastName>Mason</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Christian</FirstName>
 <LastName>Holland</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Connor</FirstName>
 <LastName>Thompson</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Conor</FirstName>
 <LastName>Hennesey</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Constantinos</FirstName>
 <LastName>Savva</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>David S</FirstName>
 <LastName>Kim</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Edward WA</FirstName>
 <LastName>Harris</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Euan J</FirstName>
 <LastName>McGivern</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Evelyn</FirstName>
 <LastName>Qian</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Evie</FirstName>
 <LastName>Rothwell</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Francesca</FirstName>
 <LastName>Back</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Gabriella</FirstName>
 <LastName>Kelly</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Gareth</FirstName>
 <LastName>Watson</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Gregory</FirstName>
 <LastName>Howgego</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Hannah</FirstName>
 <LastName>Chase</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Hannah</FirstName>
 <LastName>Danbury</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Hannah</FirstName>
 <LastName>Laurenson-Schafer</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Harry L</FirstName>
 <LastName>Ward</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Holly</FirstName>
 <LastName>Hendron</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Imogen C</FirstName>
 <LastName>Vorley</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Isabel</FirstName>
 <LastName>Tol</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>James</FirstName>
 <LastName>Gunnell</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Jocelyn LF</FirstName>
 <LastName>Ward</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Jonathan</FirstName>
 <LastName>Drake</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Joseph D</FirstName>
 <LastName>Wilson</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Joshua</FirstName>
 <LastName>Morton</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Julie</FirstName>
 <LastName>Dequaire</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Katherine</FirstName>
 <LastName>O'Byrne</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Kenzo</FirstName>
 <LastName>Motohashi</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Kirsty</FirstName>
 <LastName>Harper</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Krupa</FirstName>
 <LastName>Ravi</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Lancelot J</FirstName>
 <LastName>Millar</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Liam J</FirstName>
 <LastName>Peck</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Madeleine</FirstName>
 <LastName>Oliver</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Marcus Rex</FirstName>
 <LastName>English</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Mary</FirstName>
 <LastName>Kumarendran</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Matthew</FirstName>
 <LastName>Wedlich</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Olivia</FirstName>
 <LastName>Ambler</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Oscar T</FirstName>
 <LastName>Deal</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Owen</FirstName>
 <LastName>Sweeney</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Philip</FirstName>
 <LastName>Cowie</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Rebecca te Water</FirstName>
 <LastName>Naudé</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Rebecca</FirstName>
 <LastName>Young</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Rosie</FirstName>
 <LastName>Freer</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Samuel</FirstName>
 <LastName>Scott</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Samuel</FirstName>
 <LastName>Sussmes</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Sarah</FirstName>
 <LastName>Peters</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Saxon</FirstName>
 <LastName>Pattenden</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Seren</FirstName>
 <LastName>Waite</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Síle Ann</FirstName>
 <LastName>Johnson</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Stefan</FirstName>
 <LastName>Kourdov</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Stephanie</FirstName>
 <LastName>Santos-Paulo</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Stoyan</FirstName>
 <LastName>Dimitrov</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Sven</FirstName>
 <LastName>Kerneis</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Tariq</FirstName>
 <LastName>Ahmed-Firani</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Thomas B</FirstName>
 <LastName>King</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Thomas G</FirstName>
 <LastName>Ritter</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Thomas H</FirstName>
 <LastName>Foord</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Zoe</FirstName>
 <LastName>De Toledo</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Thomas</FirstName>
 <LastName>Christie</LastName>
+<Affiliation>University of Oxford, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Bernadett</FirstName>
 <LastName>Gergely</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>David</FirstName>
 <LastName>Axten</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Emma-Jane</FirstName>
 <LastName>Simons</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Heather</FirstName>
 <LastName>Nevard</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Jane</FirstName>
 <LastName>Philips</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Justyna</FirstName>
 <LastName>Szczurkowska</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Kaisha</FirstName>
 <LastName>Patel</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Kyla</FirstName>
 <LastName>Smit</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Laura</FirstName>
 <LastName>Warren</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Lisa</FirstName>
 <LastName>Morgan</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Lucianne</FirstName>
 <LastName>Smith</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Maria</FirstName>
 <LastName>Robles</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Mary</FirstName>
 <LastName>McKnight</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Michael</FirstName>
 <LastName>Luciw</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Michelle</FirstName>
 <LastName>Gates</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Nellia</FirstName>
 <LastName>Sande</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Rachel</FirstName>
 <LastName>Turford</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Roshni</FirstName>
 <LastName>Ray</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Sonam</FirstName>
 <LastName>Rughani</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Tracey</FirstName>
 <LastName>Mitchell</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Trisha</FirstName>
 <LastName>Bellinger</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Vicki</FirstName>
 <LastName>Wharton</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Anita</FirstName>
 <LastName>Justice</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Gerald</FirstName>
 <LastName>Jesuthasan</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Susan</FirstName>
 <LastName>Wareing</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Nurul</FirstName>
 <LastName>Huda Mohamad Fadzillah</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Kathryn</FirstName>
 <LastName>Cann</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Richard</FirstName>
 <LastName>Kirton</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Claire</FirstName>
 <LastName>Sutton</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Claudia</FirstName>
 <LastName>Salvagno</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Gabriella</FirstName>
 <LastName>DAmato</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Gemma</FirstName>
 <LastName>Pill</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Lisa</FirstName>
 <LastName>Butcher</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Lydia</FirstName>
 <LastName>Rylance-Knight</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Merline</FirstName>
 <LastName>Tabirao</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Ruth</FirstName>
 <LastName>Moroney</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 <IndividualName>
 <FirstName>Sarah</FirstName>
 <LastName>Wright</LastName>
+<Affiliation>Oxford University Hospitals NHS Foundation Trust, Oxford, United Kingdom</Affiliation>
 </IndividualName>
 </Group>
 </GroupList>

--- a/tests/test_generate_edge_cases.py
+++ b/tests/test_generate_edge_cases.py
@@ -1,5 +1,11 @@
 import unittest
-from elifearticle.article import Article, Contributor, FundingAward, RelatedArticle
+from elifearticle.article import (
+    Article,
+    Affiliation,
+    Contributor,
+    FundingAward,
+    RelatedArticle,
+)
 from elifepubmed import generate
 
 
@@ -305,23 +311,32 @@ class TestSetGroupList(unittest.TestCase):
         )
         contributor1.group_author_key = group_author_name
         article.add_contributor(contributor1)
-        contributor2 = Contributor(contrib_type="author", surname="Ant", given_name="Adam")
+        contributor2 = Contributor(
+            contrib_type="author", surname="Ant", given_name="Adam"
+        )
         contributor2.group_author_key = group_author_name
+        aff = Affiliation()
+        aff.text = "Anthill Institute"
+        contributor2.set_affiliation(aff)
         article.add_contributor(contributor2)
         # generate the PubMed XML
         p_xml = generate.build_pubmed_xml([article])
         pubmed_xml_string = p_xml.output_xml()
         self.assertIsNotNone(pubmed_xml_string)
         # assertions
-        self.assertTrue("<CollectiveName>Test Group</CollectiveName>" in str(pubmed_xml_string))
+        self.assertTrue(
+            "<CollectiveName>Test Group</CollectiveName>" in str(pubmed_xml_string)
+        )
         self.assertTrue(
             "<GroupList>"
             "<Group><GroupName>Test Group</GroupName>"
             "<IndividualName>"
             "<FirstName>Adam</FirstName>"
             "<LastName>Ant</LastName>"
+            "<Affiliation>Anthill Institute</Affiliation>"
             "</IndividualName></Group>"
-            "</GroupList>" in str(pubmed_xml_string))
+            "</GroupList>" in str(pubmed_xml_string)
+        )
 
     def test_set_group_list_complex(self):
         "test two types of collab, one with individual and one without"


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6514

Affiliations for members of a group author were not included in the PubMed XML deposit `<IndividualName>` tag.

Here, the affiliations are included, and the setting of affiliations is refactored so it can be used for both the `<Author>` and `<IndividualName>` tag.

Test fixtures are updated for existing article XML files.