### PR TITLE
Add clinical trials data to ObjectList.

### DIFF
--- a/elifepubmed/generate.py
+++ b/elifepubmed/generate.py
@@ -753,6 +753,23 @@ def set_datasets(parent, poa_article):
         set_object(parent, dataset.get('assigning_authority'), dataset.get('params'))
 
 
+def set_clinical_trials(parent, poa_article):
+    """object tags for datasets"""
+    clinical_trial_data = []
+    # next add from ref list but do not add duplicates
+    for trial in poa_article.clinical_trials:
+        if trial.source_id and trial.document_id:
+            clinical_trial = OrderedDict([
+                ('registry_type', trial.source_id),
+                ('params', {'id': trial.document_id})
+            ])
+            clinical_trial_data.append(clinical_trial)
+
+    # set the object tags
+    for clinical_trial in clinical_trial_data:
+        set_object(parent, clinical_trial.get('registry_type'), clinical_trial.get('params'))
+
+
 def set_object_list(parent, poa_article, split_article_categories):
     # Keywords and others go in Object tags
     object_list = SubElement(parent, "ObjectList")
@@ -776,6 +793,9 @@ def set_object_list(parent, poa_article, split_article_categories):
 
     # Add datasets
     set_datasets(object_list, poa_article)
+
+    # Add clinical trial data
+    set_clinical_trials(object_list, poa_article)
 
     # Finally, do not leave an empty ObjectList tag, if present
     if len(object_list) <= 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-git+https://github.com/elifesciences/elife-tools.git@a5b93afbe4db7852bf1aa12265090d60140fca8e#egg=elifetools
-git+https://github.com/elifesciences/elife-article.git@efb0f8c02b149c9f307e64be23470ae1989f540e#egg=elifearticle
+git+https://github.com/elifesciences/elife-tools.git@4e76f5eb3efecdad4a5b6ea3ee3b2254ab528586#egg=elifetools
+git+https://github.com/elifesciences/elife-article.git@9c754f54c501da3cbd0c8bfd222f30988e7f9c2a#egg=elifearticle
 configparser==3.5.0
 PyYAML==4.2b4
 coverage==4.4.2

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -3,7 +3,7 @@ import time
 import os
 from xml.etree.ElementTree import Element
 from xml.etree import ElementTree
-from elifearticle.article import Article, Citation, Dataset
+from elifearticle.article import Article, Citation, ClinicalTrial, Dataset
 from elifepubmed import generate
 from elifepubmed.conf import config, parse_raw_config
 
@@ -297,6 +297,26 @@ class TestSetDatasets(unittest.TestCase):
         article.ref_list.append(citation4)
 
         generate.set_datasets(parent_tag, article)
+        self.assertEqual(ElementTree.tostring(parent_tag), expected)
+
+
+class TestSetClinicalTrials(unittest.TestCase):
+
+    def test_set_clinical_trials(self):
+        parent_tag = Element('root')
+        expected = (
+            b'<root>'
+            b'<Object Type="ClinicalTrials.gov"><Param Name="id">TEST999</Param></Object>'
+            b'</root>')
+        article = Article()
+        clinical_trial = ClinicalTrial()
+        clinical_trial.source_id = 'ClinicalTrials.gov'
+        clinical_trial.source_id_type = 'registry-name'
+        clinical_trial.document_id = 'TEST999'
+        clinical_trial.content_type = 'preResults'
+        article.clinical_trials = [clinical_trial]
+
+        generate.set_clinical_trials(parent_tag, article)
         self.assertEqual(ElementTree.tostring(parent_tag), expected)
 
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/elife-pubmed-feed/issues/41

Clinical trials data can be added as `<Object>` tag in the `<ObjectList>`.

This will require using a recent version of the `elifearticle` library, in which the `Article` object has the `clinical_trials` property, plus the XML parsing functions in that newer library should detect the clinical trial data from the article XML abstract.